### PR TITLE
Adapt quil-site for use with p5js.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -8,7 +8,7 @@
                  [hiccup "1.0.5"]
                  [ring "1.6.3"]
                  [ring/ring-json "0.4.0"]
-                 [quil "2.8.0"]
+                 [quil "3.0.0-SNAPSHOT"]
                  [me.raynes/fs "1.4.6"]
                  [org.clojure/tools.reader "1.2.2"]
                  [org.clojure/core.cache "0.7.1"]

--- a/public/iframe.html
+++ b/public/iframe.html
@@ -11,8 +11,8 @@
     </style>
   </head>
   <body>
-    <canvas id="host" style="width: 500px; height: 500px;"
-            tabindex="0"></canvas>
+    <div id="host" style="width: 500px; height: 500px;"
+            tabindex="0"></div>
     <script src="/js/preload.js"></script>
   </body>
 </html>

--- a/src/clj/quil_site/views/about.clj
+++ b/src/clj/quil_site/views/about.clj
@@ -19,7 +19,7 @@
             [:div.example
              [:div.name]
              [:div.author]
-             [:canvas]
+             [:div.canvas-container]
              [:div.footer
               [:span.glyphicon.glyphicon-sort.hidden
                {:data-toggle "tooltip"

--- a/src/clj/quil_site/views/examples.clj
+++ b/src/clj/quil_site/views/examples.clj
@@ -13,7 +13,6 @@
            [:div.name]
            [:div.author]
            [:div.canvas-container
-            [:canvas]
             [:div.play.hidden]]
            [:div.footer
             [:span.glyphicon.glyphicon-sort.hidden

--- a/src/cljs/main/quil_site/main.cljs
+++ b/src/cljs/main/quil_site/main.cljs
@@ -52,7 +52,7 @@
   (boolean (query-selector ".container.examples-page")))
 
 (defn setup-play-pause-functionality [host sketch]
-  (pause-after-next-frame sketch)
+  ;; (pause-after-next-frame sketch)
   (let [play-button (query-selector host ".play")
         pause-button (query-selector host ".pause")]
     (classes/remove play-button "hidden")
@@ -82,7 +82,7 @@
                         display-name)
     (dom/setTextContent (query-selector host ".author")
                         (str "by " author))
-    (let [sketch (run-fn (query-selector host "canvas") 200)]
+    (let [sketch (run-fn (query-selector host ".canvas-container") 200)]
       (when (should-start-paused?)
         (setup-play-pause-functionality host sketch)))))
 

--- a/src/cljs/preload/quil_site/preload.cljs
+++ b/src/cljs/preload/quil_site/preload.cljs
@@ -11,7 +11,7 @@
                                        :keywordize-keys true)]
     (when (= type "eval")
       (js/eval source)
-      (let [canvas (.querySelector js/document "#host")]
+      (let [canvas (.querySelector js/document "canvas")]
         (.postMessage (.-top js/window)
                       #js {:type "resize-iframe"
                            :width (.-width canvas)
@@ -20,7 +20,7 @@
 
 (.addEventListener js/window EventType/MESSAGE handle-message)
 
-(.addEventListener (.querySelector js/document "canvas")
+(.addEventListener (.querySelector js/document "div#host")
                    "click"
                    #(.focus (.querySelector (.-document (.-top js/window))
                                             "iframe")))


### PR DESCRIPTION
This pull request is to prepare for adapting quil-site after the migration to p5js. The About tab, Examples tab and Editor seem to work. However:

1. How do you generate `api-2.8.0.clj` and `snippets-data-2.8.0.clj`? Is it running something like this form the quil repo?

```clj
(->> as/all-snippets
     (map #(dissoc % :body :setup))
     (clojure.pprint/pprint)
     (with-out-str)
     (spit "snippets-data.clj"))
```

2. processing.js had an `onFrameEnd` hook. Can't find anything like it in p5js. Am I understanding correctly that the purpose of `pause-after-next-frame` is to render just the first frame of the sketches?
