### PR TITLE
More changes for quil 3.0.0

### DIFF
--- a/api-3.0.0.clj
+++ b/api-3.0.0.clj
@@ -11,18 +11,30 @@
   :docstring
   "Rotates a shape around the x-axis the amount specified by the angle\n  parameter. Angles should be specified in radians (values from 0 to\n  (* PI 2)) or converted to radians with the radians function. Objects\n  are always rotated around their relative position to the origin and\n  positive numbers rotate objects in a counterclockwise\n  direction. Transformations apply to everything that happens after\n  and subsequent calls to the function accumulates the effect. For\n  example, calling (rotate-x HALF-PI) and then (rotate-x HALF-PI) is\n  the same as (rotate-x PI). If rotate-x is called within the draw fn,\n  the transformation is reset when the loop begins again. This\n  function requires either the :p3d or :opengl renderer.",
   :what :fn},
+ set-uniform
+ {:args #{[shader uniform-name data]},
+  :category "Shader",
+  :added "3.0.0",
+  :name set-uniform,
+  :subcategory nil,
+  :type :cljs,
+  :requires-bindings true,
+  :link nil,
+  :docstring
+  "Set a uniform variables inside a shader to modify the effect\n     while the program is running.",
+  :what :fn},
  print-projection
- {:args ({:value [], :type :both}),
+ {:args #{[]},
   :category "Lights, Camera",
   :added "1.0",
   :name print-projection,
   :subcategory "Camera",
-  :type :both,
+  :type :clj,
   :processing-name "printProjection()",
   :requires-bindings true,
   :link "http://www.processing.org/reference/printProjection_.html",
   :docstring
-  "Prints the current projection matrix to std out. Useful for\n  debugging",
+  "Prints the current projection matrix to std out. Useful for\n     debugging",
   :what :fn},
  screen-height
  {:args #{[]},
@@ -75,7 +87,7 @@
   :requires-bindings true,
   :link "http://www.processing.org/reference/filter_.html",
   :docstring
-  "Originally named filter in Processing Language.\n  Filters the display window with the specified mode and level.\n  Level defines the quality of the filter and mode may be one of the\n  following keywords:\n\n  :threshold - converts the image to black and white pixels depending\n               if they are above or below the threshold defined by\n               the level parameter. The level must be between\n               0.0 (black) and 1.0 (white). If no level is specified,\n               0.5 is used.\n  :gray      - converts any colors in the image to grayscale\n               equivalents. Doesn't work with level.\n  :invert    - sets each pixel to its inverse value. Doesn't work with\n               level.\n  :posterize - limits each channel of the image to the number of\n               colors specified as the level parameter. The parameter can\n               be set to values between 2 and 255, but results are most\n               noticeable in the lower ranges.\n  :blur      - executes a Guassian blur with the level parameter\n               specifying the extent of the blurring. If no level\n               parameter is used, the blur is equivalent to Guassian\n               blur of radius 1.\n  :opaque    - sets the alpha channel to entirely opaque. Doesn't work\n               with level.\n  :erode     - reduces the light areas. Doesn't work with level.\n  :dilate    - increases the light areas.  Doesn't work with level.",
+  "Originally named filter in Processing Language.\n  Filters the display window with the specified mode and level.\n  Level defines the quality of the filter and mode may be one of the\n  following keywords:\n\n  :threshold - converts the image to black and white pixels depending\n               if they are above or below the threshold defined by\n               the level parameter. The level must be between\n               0.0 (black) and 1.0 (white). If no level is specified,\n               0.5 is used.\n  :gray      - converts any colors in the image to grayscale\n               equivalents. Doesn't work with level.\n  :invert    - sets each pixel to its inverse value. Doesn't work with\n               level.\n  :posterize - limits each channel of the image to the number of\n               colors specified as the level parameter. The parameter can\n               be set to values between 2 and 255, but results are most\n               noticeable in the lower ranges.\n  :blur      - executes a Gaussian blur with the level parameter\n               specifying the extent of the blurring. If no level\n               parameter is used, the blur is equivalent to Gaussian\n               blur of radius 1.\n  :opaque    - sets the alpha channel to entirely opaque. Doesn't work\n               with level.\n  :erode     - reduces the light areas. Doesn't work with level.\n  :dilate    - increases the light areas.  Doesn't work with level.",
   :what :fn},
  rotate-z
  {:args ({:value [angle], :type :both}),
@@ -120,7 +132,7 @@
   :requires-bindings true,
   :link "http://www.processing.org/reference/blend_.html",
   :docstring
-  "Blends a region of pixels from one image into another with full alpha\n  channel support. If src is not specified it defaults to current-graphics.\n  If dest is not specified it defaults to current-graphics.\n\n  Note: blend-mode function is recommended to use instead of this one.\n\n  Available blend modes are:\n\n  :blend      - linear interpolation of colours: C = A*factor + B\n  :add        - additive blending with white clip:\n                                            C = min(A*factor + B, 255)\n  :subtract   - subtractive blending with black clip:\n                                            C = max(B - A*factor, 0)\n  :darkest    - only the darkest colour succeeds:\n                                            C = min(A*factor, B)\n  :lightest   - only the lightest colour succeeds:\n                                            C = max(A*factor, B)\n  :difference - subtract colors from underlying image.\n  :exclusion  - similar to :difference, but less extreme.\n  :multiply   - Multiply the colors, result will always be darker.\n  :screen     - Opposite multiply, uses inverse values of the colors.\n  :overlay    - A mix of :multiply and :screen. Multiplies dark values\n                and screens light values.\n  :hard-light - :screen when greater than 50% gray, :multiply when\n                lower.\n  :soft-light - Mix of :darkest and :lightest. Works like :overlay,\n                but not as harsh.\n  :dodge      - Lightens light tones and increases contrast, ignores\n                darks.\n                Called \"Color Dodge\" in Illustrator and Photoshop.\n  :burn       - Darker areas are applied, increasing contrast, ignores\n                lights. Called \"Color Burn\" in Illustrator and\n                Photoshop.",
+  "Blends a region of pixels from one image into another with full alpha\n  channel support. If src is not specified it defaults to current-graphics.\n  If dest is not specified it defaults to current-graphics.\n\n  Note: blend-mode function is recommended to use instead of this one.\n\n  Available blend modes are:\n\n  :blend      - linear interpolation of colours: C = A*factor + B\n  :add        - additive blending with white clip:\n                                            C = min(A*factor + B, 255)\n  :darkest    - only the darkest colour succeeds:\n                                            C = min(A*factor, B)\n  :lightest   - only the lightest colour succeeds:\n                                            C = max(A*factor, B)\n  :difference - subtract colors from underlying image.\n  :exclusion  - similar to :difference, but less extreme.\n  :multiply   - Multiply the colors, result will always be darker.\n  :screen     - Opposite multiply, uses inverse values of the colors.\n  :overlay    - A mix of :multiply and :screen. Multiplies dark values\n                and screens light values.\n  :hard-light - :screen when greater than 50% gray, :multiply when\n                lower.\n  :soft-light - Mix of :darkest and :lightest. Works like :overlay,\n                but not as harsh.\n  :dodge      - Lightens light tones and increases contrast, ignores\n                darks.\n                Called \"Color Dodge\" in Illustrator and Photoshop.\n  :burn       - Darker areas are applied, increasing contrast, ignores\n                lights. Called \"Color Burn\" in Illustrator and\n                Photoshop.\n\n  In clj the following blend modes are also supported:\n  :subtract   - subtractive blending with black clip:\n                                            C = max(B - A*factor, 0)\n\n  In cljs the following blend modes are also supported:\n  :replace    - the pixels entirely replace the others and don't utilize\n                alpha (transparency) values.",
   :what :fn},
  frame-count
  {:args ({:value [], :type :both}),
@@ -147,18 +159,17 @@
   :docstring
   "All subsequent calls of any drawing function will draw on given\n  graphics. 'with-graphics' cannot be nested (you can draw simultaneously\n  only on 1 graphics)",
   :what :macro},
- model-y
- {:args ({:value [x y z], :type :both}),
-  :category "Lights, Camera",
-  :added "1.0",
-  :name model-y,
-  :subcategory "Coordinates",
+ loaded?
+ {:args ({:value [object], :type :both}),
+  :category "Environment",
+  :added "3.0.0",
+  :name loaded?,
+  :subcategory nil,
   :type :both,
-  :processing-name "modelY()",
-  :requires-bindings true,
-  :link "http://www.processing.org/reference/modelY_.html",
-  :docstring
-  "Returns the three-dimensional x, y, z position in model space. This\n  returns the y value for a given coordinate based on the current set\n  of transformations (scale, rotate, translate, etc.) The y value can\n  be used to place an object in space relative to the location of the\n  original point once the transformations are no longer in use.",
+  :processing-name nil,
+  :requires-bindings false,
+  :link nil,
+  :docstring "Returns true if object is loaded.",
   :what :fn},
  set-image
  {:args ({:value [x y src], :type :both}),
@@ -174,35 +185,34 @@
   "Writes an image directly into the display window. The x and y\n  parameters define the coordinates for the upper-left corner of the\n  image.",
   :what :fn},
  shape-mode
- {:args ({:value [mode], :type :both}),
+ {:args #{[mode]},
   :category "Shape",
   :added "1.0",
   :name shape-mode,
   :subcategory "Loading & Displaying",
-  :type :both,
+  :type :clj,
   :processing-name "shapeMode()",
   :requires-bindings true,
   :link "http://www.processing.org/reference/shapeMode_.html",
   :docstring
-  "Modifies the location from which shapes draw. Available modes are\n  :corner, :corners and :center. Default is :corner.\n\n  :corner  - specifies the location to be the upper left corner of the\n             shape and uses the third and fourth parameters of shape\n             to specify the width and height.\n\n  :corners - uses the first and second parameters of shape to set\n             the location of one corner and uses the third and fourth\n             parameters to set the opposite corner.\n\n  :center  - draws the shape from its center point and uses the third\n             and forth parameters of shape to specify the width and\n             height. ",
+  "Modifies the location from which shapes draw. Available modes are\n     :corner, :corners and :center. Default is :corner.\n\n     :corner  - specifies the location to be the upper left corner of the\n                shape and uses the third and fourth parameters of shape\n                to specify the width and height.\n\n     :corners - uses the first and second parameters of shape to set\n                the location of one corner and uses the third and fourth\n                parameters to set the opposite corner.\n\n     :center  - draws the shape from its center point and uses the third\n                and forth parameters of shape to specify the width and\n                height. ",
   :what :fn},
  cursor-image
- {:args
-  ({:value [img hx hy], :type :both} {:value [img], :type :both}),
+ {:args #{[img hx hy] [img]},
   :category "Environment",
   :added "1.0",
   :name cursor-image,
   :subcategory nil,
-  :type :both,
+  :type :clj,
   :processing-name "cursor()",
   :requires-bindings true,
   :link "http://www.processing.org/reference/cursor_.html",
   :docstring
-  "Set the cursor to a predefined image. The horizontal and vertical\n  active spots of the cursor may be specified with hx and hy.\n  It is recommended to make the size 16x16 or 32x32 pixels.",
+  "Set the cursor to a predefined image. The horizontal and vertical\n     active spots of the cursor may be specified with hx and hy.\n     It is recommended to make the size 16x16 or 32x32 pixels.",
   :what :fn},
  create-graphics
  {:args
-  ({:value [w h renderer path], :type :both}
+  ({:value [w h renderer path], :type :clj}
    {:value [w h], :type :both}
    {:value [w h renderer], :type :both}),
   :category "Image",
@@ -280,19 +290,6 @@
   :link "http://www.processing.org/reference/constrain_.html",
   :docstring
   "Constrains a value to not exceed a maximum and minimum value.",
-  :what :fn},
- screen-y
- {:args ({:value [x y], :type :both} {:value [x y z], :type :both}),
-  :category "Lights, Camera",
-  :added "1.0",
-  :name screen-y,
-  :subcategory "Coordinates",
-  :type :both,
-  :processing-name "screenY()",
-  :requires-bindings true,
-  :link "http://www.processing.org/reference/screenY_.html",
-  :docstring
-  "Takes a three-dimensional x, y, z position and returns the y value\n  for where it will appear on a (two-dimensional) screen, once\n  affected by translate, scale or any other transformations",
   :what :fn},
  reset-shader
  {:args #{[kind] []},
@@ -372,17 +369,17 @@
   "Set of key modifiers that were pressed when event happened.\n  Possible modifiers :ctrl, :alt, :shift, :meta. Not available in\n  ClojureScript.",
   :what :fn},
  end-raw
- {:args ({:value [], :type :both}),
+ {:args #{[]},
   :category "Output",
   :added "1.0",
   :name end-raw,
   :subcategory "Files",
-  :type :both,
+  :type :clj,
   :processing-name "endRaw()",
   :requires-bindings true,
   :link "http://www.processing.org/reference/endRaw_.html",
   :docstring
-  "Complement to begin-raw; they must always be used together. See\n  the begin-raw docstring for details.",
+  "Complement to begin-raw; they must always be used together. See\n     the begin-raw docstring for details.",
   :what :fn},
  radians
  {:args ({:value [degrees], :type :both}),
@@ -423,6 +420,19 @@
   :docstring
   "The inverse of cos, returns the arc cosine of a value. This\n  function expects the values in the range of -1 to 1 and values are\n  returned in the range 0 to Math/PI (3.1415927).",
   :what :fn},
+ angle-mode
+ {:args #{[mode]},
+  :category "Math",
+  :added "2.8.0",
+  :name angle-mode,
+  :subcategory "Trigonometry",
+  :type :cljs,
+  :processing-name "angleMode()",
+  :requires-bindings true,
+  :link "http://www.processing.org/reference/angleMode_.html",
+  :docstring
+  "Sets the current mode of p5 to given mode. Default mode is :radians.",
+  :what :fn},
  bezier-detail
  {:args ({:value [detail], :type :both}),
   :category "Shape",
@@ -450,12 +460,12 @@
   "Sets a texture to be applied to vertex points. The texture fn must\n  be called between begin-shape and end-shape and before any calls to\n  vertex.\n\n  When textures are in use, the fill color is ignored. Instead, use\n  tint to specify the color of the texture as it is applied to the\n  shape.",
   :what :fn},
  print-camera
- {:args ({:value [], :type :both}),
+ {:args #{[]},
   :category "Lights, Camera",
   :added "1.0",
   :name print-camera,
   :subcategory "Camera",
-  :type :both,
+  :type :clj,
   :processing-name "printCamera()",
   :requires-bindings true,
   :link "http://www.processing.org/reference/printCamera_.html",
@@ -489,17 +499,18 @@
   "Calculates the angle (in radians) from a specified point to the\n  coordinate origin as measured from the positive x-axis. Values are\n  returned as a float in the range from PI to -PI. The atan2 function\n  is most often used for orienting geometry to the position of the\n  cursor. Note: The y-coordinate of the point is the first parameter\n  and the x-coordinate is the second due to the structure of\n  calculating the tangent.",
   :what :fn},
  shader
- {:args #{[shader kind] [shader]},
+ {:args
+  ({:value [shader kind], :type :clj} {:value [shader], :type :both}),
   :category "Rendering",
   :added "2.0",
   :name shader,
   :subcategory "Shaders",
-  :type :clj,
+  :type :both,
   :processing-name "shader()",
   :requires-bindings true,
   :link "http://www.processing.org/reference/shader_.html",
   :docstring
-  "Applies the shader specified by the parameters. It's compatible with the :p2d\n  and :p3drenderers, but not with the default :java2d renderer. Optional 'kind'\n  parameter - type of shader, either :points, :lines, or :triangles",
+  "Applies the shader specified by the parameters. It's compatible with the :p2d\n  and :p3d renderers, but not with the default :java2d renderer.\n  In clj mode you can pass an optional 'kind' parameter that specifies\n  the type of shader, either :points, :lines, or :triangles",
   :what :fn},
  millis
  {:args ({:value [], :type :both}),
@@ -555,10 +566,11 @@
   :requires-bindings true,
   :link "http://www.processing.org/reference/colorMode_.html",
   :docstring
-  "Changes the way Processing interprets color data. Available modes\n  are :rgb and :hsb.By default, the parameters for fill, stroke,\n  background, and color are defined by values between 0 and 255 using\n  the :rgb color model. The color-mode fn is used to change the\n  numerical range used for specifying colors and to switch color\n  systems. For example, calling\n  (color-mode :rgb 1.0) will specify that values are specified between\n  0 and 1. The limits for defining colors are altered by setting the\n  parameters range1, range2, range3, and range 4.",
+  "Changes the way Processing interprets color data. Available modes\n  are :rgb and :hsb (and :hsl in clojurescript).\n  By default, the parameters for fill, stroke,\n  background, and color are defined by values between 0 and 255 using\n  the :rgb color model. The color-mode fn is used to change the\n  numerical range used for specifying colors and to switch color\n  systems. For example, calling\n  (color-mode :rgb 1.0) will specify that values are specified between\n  0 and 1. The limits for defining colors are altered by setting the\n  parameters range1, range2, range3, and range 4.",
   :what :fn},
  create-image
- {:args ({:value [w h format], :type :both}),
+ {:args
+  ({:value [w h format], :type :clj} {:value [w h], :type :cljs}),
   :category "Image",
   :added "1.0",
   :name create-image,
@@ -568,7 +580,7 @@
   :requires-bindings true,
   :link "http://www.processing.org/reference/createImage_.html",
   :docstring
-  "Creates a new PImage (the datatype for storing images). This\n  provides a fresh buffer of pixels to play with. Set the size of the\n  buffer with the width and height parameters. The format parameter\n  defines how the pixels are stored. See the PImage reference for more\n  information.\n\n  Possible formats: :rgb, :argb, :alpha (grayscale alpha channel)\n\n  Prefer using create-image over initialising new PImage instances\n  directly.",
+  "Creates a new datatype for storing images (PImage for clj and\n  Image for cljs). This provides a fresh buffer of pixels to play\n  with. Set the size of the buffer with the width and height\n  parameters.\n\n  In clj the format parameter defines how the pixels are stored.\n  See the PImage reference for more information.\n  Possible formats: :rgb, :argb, :alpha (grayscale alpha channel)\n\n  Prefer using create-image over initialising new PImage (or Image)\n  instances directly.",
   :what :fn},
  sq
  {:args ({:value [a], :type :both}),
@@ -638,7 +650,7 @@
  {:args
   ({:value [s x1 y1 x2 y2], :type :both}
    {:value [s x y], :type :both}
-   {:value [s x y z], :type :both}),
+   {:value [s x y z], :type :clj}),
   :category "Typography",
   :added "1.0",
   :name text,
@@ -648,28 +660,28 @@
   :requires-bindings true,
   :link "http://www.processing.org/reference/text_.html",
   :docstring
-  "Draws text to the screen in the position specified by the x and y\n  parameters and the optional z parameter. A default font will be used\n  unless a font is set with the text-font fn. Change the color of the\n  text with the fill fn. The text displays in relation to the\n  text-align fn, which gives the option to draw to the left, right, and\n  center of the coordinates.\n\n  The x1, y1, x2 and y2 parameters define a\n  rectangular area to display within and may only be used with string\n  data. For text drawn inside a rectangle, the coordinates are\n  interpreted based on the current rect-mode setting.",
+  "Draws text to the screen in the position specified by the x and y\n  parameters (and the optional z parameter in clj). A default font will be used\n  unless a font is set with the text-font fn. Change the color of the\n  text with the fill fn. The text displays in relation to the\n  text-align fn, which gives the option to draw to the left, right, and\n  center of the coordinates.\n\n  The x1, y1, x2 and y2 parameters define a\n  rectangular area to display within and may only be used with string\n  data. For text drawn inside a rectangle, the coordinates are\n  interpreted based on the current rect-mode setting.",
   :what :fn},
  available-fonts
- {:args ({:value [], :type :both}),
+ {:args #{[]},
   :category "Typography",
   :added "1.0",
   :name available-fonts,
   :subcategory "Loading & Displaying",
-  :type :both,
+  :type :clj,
   :processing-name "PFont.list()",
   :requires-bindings false,
   :link "http://www.processing.org/reference/PFont_list_.html",
   :docstring
-  "A sequence of strings representing the fonts on this system\n  available for use.\n\n  Because of limitations in Java, not all fonts can be used and some\n  might work with one operating system and not others. When sharing a\n  sketch with other people or posting it on the web, you may need to\n  include a .ttf or .otf version of your font in the data directory of\n  the sketch because other people might not have the font installed on\n  their computer. Only fonts that can legally be distributed should be\n  included with a sketch.",
+  "A sequence of strings representing the fonts on this system\n    available for use.\n\n    Because of limitations in Java, not all fonts can be used and some\n    might work with one operating system and not others. When sharing a\n    sketch with other people or posting it on the web, you may need to\n    include a .ttf or .otf version of your font in the data directory of\n    the sketch because other people might not have the font installed on\n    their computer. Only fonts that can legally be distributed should be\n    included with a sketch.",
   :what :fn},
  clear
- {:args #{[]},
+ {:args ({:value [], :type :both}),
   :category "Color",
   :added "2.4.0",
   :name clear,
   :subcategory "Setting",
-  :type :clj,
+  :type :both,
   :processing-name "clear()",
   :requires-bindings true,
   :link "http://www.processing.org/reference/clear_.html",
@@ -713,7 +725,7 @@
   :requires-bindings true,
   :link "http://www.processing.org/reference/popMatrix_.html",
   :docstring
-  "Pops the current transformation matrix off the matrix\n  stack. Understanding pushing and popping requires understanding the\n  concept of a matrix stack. The push-matrix fn saves the current\n  coordinate system to the stack and pop-matrix restores the prior\n  coordinate system. push-matrix and pop-matrix are used in conjuction\n  with the other transformation methods and may be embedded to control\n  the scope of the transformations.",
+  "Pops the current transformation matrix off the matrix\n  stack. Understanding pushing and popping requires understanding the\n  concept of a matrix stack. The push-matrix fn saves the current\n  coordinate system to the stack and pop-matrix restores the prior\n  coordinate system. push-matrix and pop-matrix are used in conjunction\n  with the other transformation methods and may be embedded to control\n  the scope of the transformations.",
   :what :fn},
  ceil
  {:args ({:value [n], :type :both}),
@@ -754,19 +766,6 @@
   :docstring
   "Generates a hollow ball made from tessellated triangles.",
   :what :fn},
- request-image
- {:args ({:value [filename], :type :both}),
-  :category "Image",
-  :added "1.0",
-  :name request-image,
-  :subcategory "Loading & Displaying",
-  :type :both,
-  :processing-name "requestImage()",
-  :requires-bindings true,
-  :link "http://www.processing.org/reference/requestImage_.html",
-  :docstring
-  "This function load images on a separate thread so that your sketch\n  does not freeze while images load during setup. While the image is\n  loading, its width and height will be 0. If an error occurs while\n  loading the image, its width and height will be set to -1. You'll\n  know when the image has loaded properly because its width and height\n  will be greater than 0. Asynchronous image loading (particularly\n  when downloading from a server) can dramatically improve\n  performance.",
-  :what :fn},
  hue
  {:args ({:value [col], :type :both}),
   :category "Color",
@@ -791,6 +790,18 @@
   :link "http://www.processing.org/reference/loop_.html",
   :docstring
   "Causes Processing to continuously execute the code within\n  draw. If no-loop is called, the code in draw stops executing.",
+  :what :fn},
+ orbit-control
+ {:args #{[]},
+  :category "Lights, Camera",
+  :added "3.0.0",
+  :name orbit-control,
+  :subcategory "Camera",
+  :type :cljs,
+  :processing-name "orbitControl()",
+  :requires-bindings true,
+  :link "http://www.processing.org/reference/orbitControl_.html",
+  :docstring "Allows the camera to orbit around a target using mouse.",
   :what :fn},
  curve-vertex
  {:args ({:value [x y], :type :both} {:value [x y z], :type :both}),
@@ -1055,12 +1066,12 @@
   :docstring "true if any key is currently pressed, false otherwise.",
   :what :fn},
  display-density
- {:args #{[display] []},
+ {:args ({:value [display], :type :both} {:value [], :type :both}),
   :category "Environment",
   :added "2.4.0",
   :name display-density,
   :subcategory nil,
-  :type :clj,
+  :type :both,
   :processing-name "displayDensity()",
   :requires-bindings true,
   :link "http://www.processing.org/reference/displayDensity_.html",
@@ -1093,15 +1104,15 @@
   :requires-bindings true,
   :link "http://www.processing.org/reference/clip_.html",
   :docstring
-  "Limits the rendering to the boundaries of a rectangle defined by\n  the parameters. The boundaries are drawn based on the state of\n  the (image-mode) fuction, either :corner, :corners, or :center.\n  To disable use (no-clip).",
+  "Limits the rendering to the boundaries of a rectangle defined by\n  the parameters. The boundaries are drawn based on the state of\n  the (image-mode) function, either :corner, :corners, or :center.\n  To disable use (no-clip).",
   :what :fn},
  pixel-density
- {:args #{[density]},
+ {:args ({:value [density], :type :both}),
   :category "Environment",
   :added "2.4.0",
   :name pixel-density,
   :subcategory nil,
-  :type :clj,
+  :type :both,
   :processing-name "pixelDensity()",
   :requires-bindings true,
   :link "http://www.processing.org/reference/pixelDensity_.html",
@@ -1138,8 +1149,9 @@
  {:args
   ({:value
     [n00 n01 n02 n03 n10 n11 n12 n13 n20 n21 n22 n23 n30 n31 n32 n33],
-    :type :both}
-   {:value [n00 n01 n02 n10 n11 n12], :type :clj}),
+    :type :clj}
+   {:value [n00 n01 n02 n10 n11 n12], :type :clj}
+   {:value [a b c d e f], :type :cljs}),
   :category "Transform",
   :added "1.0",
   :name apply-matrix,
@@ -1149,7 +1161,7 @@
   :requires-bindings true,
   :link "http://www.processing.org/reference/applyMatrix_.html",
   :docstring
-  "Multiplies the current matrix by the one specified through the\n  parameters. This is very slow because it will try to calculate the\n  inverse of the transform, so avoid it whenever possible. The\n  equivalent function in OpenGL is glMultMatrix().",
+  "Multiplies the current matrix by the one specified through the\n  parameters. This is very slow because it will try to calculate the\n  inverse of the transform, so avoid it whenever possible. The\n  equivalent function in OpenGL is glMultMatrix().\n\n  Note that cljs has only 2d version and arguments differ see\n  https://p5js.org/reference/#/p5/applyMatrix",
   :what :fn},
  copy
  {:args
@@ -1169,7 +1181,7 @@
   :requires-bindings true,
   :link "http://www.processing.org/reference/copy_.html",
   :docstring
-  "Copies a region of pixels from the one image to another. If src-img\n  is not specified it defaults to current-graphics. If dest-img is not\n  specified - it defaults to current-graphics. If the source\n  and destination regions aren't the same size, it will automatically\n  resize the source pixels to fit the specified target region. No\n  alpha information is used in the process, however if the source\n  image has an alpha channel set, it will be copied as well. ",
+  "Copies a region of pixels from one image to another. If src-img\n  is not specified it defaults to current-graphics. If dest-img is not\n  specified - it defaults to current-graphics. If the source\n  and destination regions aren't the same size, it will automatically\n  resize the source pixels to fit the specified target region. No\n  alpha information is used in the process, however if the source\n  image has an alpha channel set, it will be copied as well. ",
   :what :fn},
  random-3d
  {:args ({:value [], :type :both}),
@@ -1274,12 +1286,12 @@
   "A triangle is a plane created by connecting three points. The first\n  two arguments specify the first point, the middle two arguments\n  specify the second point, and the last two arguments specify the\n  third point.",
   :what :fn},
  emissive
- {:args ({:value [gray], :type :both} {:value [r g b], :type :both}),
+ {:args #{[gray] [r g b]},
   :category "Lights, Camera",
   :added "1.0",
   :name emissive,
   :subcategory "Material Properties",
-  :type :both,
+  :type :clj,
   :processing-name "emissive()",
   :requires-bindings true,
   :link "http://www.processing.org/reference/emissive_.html",
@@ -1313,12 +1325,12 @@
   :requires-bindings true,
   :link "http://www.processing.org/reference/color_.html",
   :docstring
-  "Creates an integer representation of a color The parameters are\n  interpreted as RGB or HSB values depending on the current\n  color-mode. The default mode is RGB values from 0 to 255 and\n  therefore, the function call (color 255 204 0) will return a bright\n  yellow. Args are cast to floats.\n\n  r - red or hue value\n  g - green or saturation value\n  b - blue or brightness value\n  a - alpha value",
+  "Creates an integer representation of a color. The parameters are\n  interpreted as RGB or HSB values depending on the current\n  color-mode. The default mode is RGB values from 0 to 255 and\n  therefore, the function call (color 255 204 0) will return a bright\n  yellow. Args are cast to floats.\n\n  r - red or hue value\n  g - green or saturation value\n  b - blue or brightness value\n  a - alpha value",
   :what :fn},
  arc
  {:args
   ({:value [x y width height start stop], :type :both}
-   {:value [x y width height start stop mode], :type :clj}),
+   {:value [x y width height start stop mode], :type :both}),
   :category "Shape",
   :added "1.0",
   :name arc,
@@ -1370,7 +1382,7 @@
   :docstring "Current horizontal coordinate of the mouse.",
   :what :fn},
  mag
- {:args ({:value [a b c], :type :both} {:value [a b], :type :both}),
+ {:args ({:value [a b c], :type :clj} {:value [a b], :type :both}),
   :category "Math",
   :added "1.0",
   :name mag,
@@ -1407,19 +1419,6 @@
   :link "http://www.processing.org/reference/map_.html",
   :docstring
   "Re-maps a number from one range to another.\n\n  Numbers outside the range are not clamped to 0 and 1, because\n  out-of-range values are often intentional and useful.",
-  :what :fn},
- model-x
- {:args ({:value [x y z], :type :both}),
-  :category "Lights, Camera",
-  :added "1.0",
-  :name model-x,
-  :subcategory "Coordinates",
-  :type :both,
-  :processing-name "modelX()",
-  :requires-bindings true,
-  :link "http://www.processing.org/reference/modelX_.html",
-  :docstring
-  "Returns the three-dimensional x, y, z position in model space. This\n  returns the x value for a given coordinate based on the current set\n  of transformations (scale, rotate, translate, etc.) The x value can\n  be used to place an object in space relative to the location of the\n  original point once the transformations are no longer in use.",
   :what :fn},
  sqrt
  {:args ({:value [a], :type :both}),
@@ -1486,7 +1485,7 @@
   :requires-bindings true,
   :link "http://www.processing.org/reference/scale_.html",
   :docstring
-  "Increases or decreases the size of a shape by expanding and\n  contracting vertices. Objects always scale from their relative\n  origin to the coordinate system. Scale values are specified as\n  decimal percentages. For example, the function call (scale 2)\n  increases the dimension of a shape by 200%. Transformations apply to\n  everything that happens after and subsequent calls to the function\n  multiply the effect. For example, calling (scale 2) and then\n  (scale 1.5) is the same as (scale 3). If scale is called within\n  draw, the transformation is reset when the loop begins again. Using\n  this fuction with the z parameter requires specfying :p3d or :opengl\n  as the renderer. This function can be further controlled by\n  push-matrix and pop-matrix.",
+  "Increases or decreases the size of a shape by expanding and\n  contracting vertices. Objects always scale from their relative\n  origin to the coordinate system. Scale values are specified as\n  decimal percentages. For example, the function call (scale 2)\n  increases the dimension of a shape by 200%. Transformations apply to\n  everything that happens after and subsequent calls to the function\n  multiply the effect. For example, calling (scale 2) and then\n  (scale 1.5) is the same as (scale 3). If scale is called within\n  draw, the transformation is reset when the loop begins again. Using\n  this function with the z parameter requires specifying :p3d or :opengl\n  as the renderer. This function can be further controlled by\n  push-matrix and pop-matrix.",
   :what :fn},
  defsketch
  {:args ({:value [app-name & options], :type :both}),
@@ -1498,7 +1497,7 @@
   :requires-bindings false,
   :link nil,
   :docstring
-  "Define and start a sketch and bind it to a var with the symbol\n  app-name. If any of the options to the various callbacks are\n  symbols, it wraps them in a call to var to ensure they aren't\n  inlined and that redefinitions to the original fns are reflected in\n  the visualisation.\n\n  Available options:\n\n   :size           - A vector of width and height for the sketch or :fullscreen.\n                     Defaults to [500 300]. If you're using :fullscreen you may\n                     want to enable present mode - :features [:present].\n                     :fullscreen size works only in Clojure. In ClojureScript\n                     all sketches are support fullscreen when you press F11.\n\n   :renderer       - Specifies the renderer type. One of :p2d, :p3d, :java2d,\n                     :opengl, :pdf). Defaults to :java2d. :dxf renderer\n                     can't be used as sketch renderer. Use begin-raw method\n                     instead. In clojurescript only :p2d and :p3d renderers\n                     are supported.\n\n   :output-file    - Specifies an output file path. Only used in :pdf mode.\n                     Not supported in clojurescript.\n\n   :title          - A string which will be displayed at the top of\n                     the sketch window. Not supported in clojurescript.\n\n   :features       - A vector of keywords customizing sketch behaviour.\n                     Supported features:\n\n                     :keep-on-top - Sketch window will always be above other\n                                    windows. Note: some platforms might not\n                                    support always-on-top windows.\n                                    Not supported in clojurescript.\n\n                     :exit-on-close - Shutdown JVM  when sketch is closed.\n                                      Not supported in clojurescript.\n\n                     :resizable - Makes sketch resizable.\n                                  Not supported in clojurescript.\n\n                     :no-safe-fns - Do not catch and print exceptions thrown\n                                    inside functions provided to sketch (like\n                                    draw, mouse-click, key-pressed and\n                                    other). By default all exceptions thrown\n                                    inside these functions are catched. This\n                                    prevents sketch from breaking when bad\n                                    function was provided and allows you to\n                                    fix it and reload it on fly. You can\n                                    disable this behaviour by enabling\n                                    :no-safe-fns feature.\n                                    Not supported in clojurescript.\n\n                     :present - Switch to present mode (fullscreen without\n                                borders, OS panels). You may want to use\n                                this feature together with :size :fullscreen.\n                                Not supported in ClojureScript. In ClojureScript\n                                fullscreen is enabled by pressing F11 and it's\n                                enabled on all sketches automatically.\n\n                     :no-start - Disables autostart if sketch was created using\n                                 defsketch macro. To start sketch you have to\n                                 call function created defsketch.\n                                 Supported only in ClojureScript.\n\n                     :global-key-events - Allows a sketch to receive any\n                                          keyboard event sent to the page,\n                                          regardless of whether the canvas it is\n                                          loaded in has focus or not.\n                                          Supported only in ClojureScript.\n\n                     Usage example: :features [:keep-on-top :present]\n\n   :bgcolor        - Sets background color for unused space in present mode.\n                     Color is specified in hex format: #XXXXXX.\n                     Example: :bgcolor \"#00FFFF\" (cyan background)\n                     Not supported in ClojureScript.\n\n   :display        - Sets what display should be used by this sketch.\n                     Displays are numbered starting from 0. Example: :display 1.\n                     Not supported in ClojureScript.\n\n   :setup          - A function to be called once when setting the sketch up.\n\n   :draw           - A function to be repeatedly called at most n times per\n                     second where n is the target frame-rate set for\n                     the visualisation.\n\n   :host           - String id of canvas element or DOM element itself.\n                     Specifies host for the sketch. Must be specified in sketch,\n                     may be omitted in defsketch. If ommitted in defsketch,\n                     :host is set to the name of the sketch. If element with\n                     specified id is not found on the page and page is empty -\n                     new canvas element will be created. Used in ClojureScript.\n\n   :focus-gained   - Called when the sketch gains focus.\n                     Not supported in ClojureScript.\n\n   :focus-lost     - Called when the sketch loses focus.\n                     Not supported in ClojureScript.\n\n   :mouse-entered  - Called when the mouse enters the sketch window.\n\n   :mouse-exited   - Called when the mouse leaves the sketch window\n\n   :mouse-pressed  - Called every time a mouse button is pressed.\n\n   :mouse-released - Called every time a mouse button is released.\n\n   :mouse-clicked  - called once after a mouse button has been pressed\n                     and then released.\n\n   :mouse-moved    - Called every time the mouse moves and a button is\n                     not pressed.\n\n   :mouse-dragged  - Called every time the mouse moves and a button is\n                     pressed.\n\n   :mouse-wheel    - Called every time mouse wheel is rotated.\n                     Takes 1 argument - wheel rotation, an int.\n                     Negative values if the mouse wheel was rotated\n                     up/away from the user, and positive values\n                     if the mouse wheel was rotated down/ towards the user\n\n   :key-pressed    - Called every time any key is pressed.\n\n   :key-released   - Called every time any key is released.\n\n   :key-typed      - Called once every time non-modifier keys are\n                     pressed.\n\n   :on-close       - Called once, when sketch is closed\n                     Not supported in ClojureScript.\n\n   :middleware     - Vector of middleware to be applied to the sketch.\n                     Middleware will be applied in the same order as in comp\n                     function: [f g] will be applied as (f (g options)).\n\n   :settings       - cousin of :setup. A function to be called once when\n                     setting sketch up. Should be used only for (smooth) and\n                     (no-smooth). Due to Processing limitations these functions\n                     cannot be used neither in :setup nor in :draw.",
+  "Define and start a sketch and bind it to a var with the symbol\n  app-name. If any of the options to the various callbacks are\n  symbols, it wraps them in a call to var to ensure they aren't\n  inlined and that redefinitions to the original fns are reflected in\n  the visualisation.\n\n  Available options:\n\n   :size           - A vector of width and height for the sketch or :fullscreen.\n                     Defaults to [500 300]. If you're using :fullscreen you may\n                     want to enable present mode - :features [:present].\n                     :fullscreen size works only in Clojure. In ClojureScript\n                     all sketches are support fullscreen when you press F11.\n\n   :renderer       - Specifies the renderer type. One of :p2d, :p3d, :java2d,\n                     :opengl, :pdf, :svg). Defaults to :java2d. :dxf renderer\n                     can't be used as sketch renderer. Use begin-raw method\n                     instead. In clojurescript only :p2d and :p3d renderers\n                     are supported.\n\n   :output-file    - Specifies an output file path. Only used in :pdf and :svg modes.\n                     Not supported in clojurescript. When writing to a file, call\n                     `(q/exit)` at the end of the draw call to end the sketch and not\n                     write repeatedly to the file.\n\n   :title          - A string which will be displayed at the top of\n                     the sketch window. Not supported in clojurescript.\n\n   :features       - A vector of keywords customizing sketch behaviour.\n                     Supported features:\n\n                     :keep-on-top - Sketch window will always be above other\n                                    windows. Note: some platforms might not\n                                    support always-on-top windows.\n                                    Not supported in clojurescript.\n\n                     :exit-on-close - Shutdown JVM  when sketch is closed.\n                                      Not supported in clojurescript.\n\n                     :resizable - Makes sketch resizable.\n                                  Not supported in clojurescript.\n\n                     :no-safe-fns - Do not catch and print exceptions thrown\n                                    inside functions provided to sketch (like\n                                    draw, mouse-click, key-pressed and\n                                    other). By default all exceptions thrown\n                                    inside these functions are caught. This\n                                    prevents sketch from breaking when bad\n                                    function was provided and allows you to\n                                    fix it and reload it on fly. You can\n                                    disable this behaviour by enabling\n                                    :no-safe-fns feature.\n                                    Not supported in clojurescript.\n\n                     :present - Switch to present mode (fullscreen without\n                                borders, OS panels). You may want to use\n                                this feature together with :size :fullscreen.\n                                Not supported in ClojureScript. In ClojureScript\n                                fullscreen is enabled by pressing F11 and it's\n                                enabled on all sketches automatically.\n\n                     :no-start - Disables autostart if sketch was created using\n                                 defsketch macro. To start sketch you have to\n                                 call function created defsketch.\n                                 Supported only in ClojureScript.\n\n                     :global-key-events - Allows a sketch to receive any\n                                          keyboard event sent to the page,\n                                          regardless of whether the canvas it is\n                                          loaded in has focus or not.\n                                          Supported only in ClojureScript.\n\n                     Usage example: :features [:keep-on-top :present]\n\n   :bgcolor        - Sets background color for unused space in present mode.\n                     Color is specified in hex format: #XXXXXX.\n                     Example: :bgcolor \"#00FFFF\" (cyan background)\n                     Not supported in ClojureScript.\n\n   :display        - Sets what display should be used by this sketch.\n                     Displays are numbered starting from 0. Example: :display 1.\n                     Not supported in ClojureScript.\n\n   :setup          - A function to be called once when setting the sketch up.\n\n   :draw           - A function to be repeatedly called at most n times per\n                     second where n is the target frame-rate set for\n                     the visualisation.\n\n   :host           - String id of canvas element or DOM element itself.\n                     Specifies host for the sketch. Must be specified in sketch,\n                     may be omitted in defsketch. If omitted in defsketch,\n                     :host is set to the name of the sketch. If element with\n                     specified id is not found on the page and page is empty -\n                     new canvas element will be created. Used in ClojureScript.\n\n   :focus-gained   - Called when the sketch gains focus.\n                     Not supported in ClojureScript.\n\n   :focus-lost     - Called when the sketch loses focus.\n                     Not supported in ClojureScript.\n\n   :mouse-entered  - Called when the mouse enters the sketch window.\n\n   :mouse-exited   - Called when the mouse leaves the sketch window\n\n   :mouse-pressed  - Called every time a mouse button is pressed.\n\n   :mouse-released - Called every time a mouse button is released.\n\n   :mouse-clicked  - called once after a mouse button has been pressed\n                     and then released.\n\n   :mouse-moved    - Called every time the mouse moves and a button is\n                     not pressed.\n\n   :mouse-dragged  - Called every time the mouse moves and a button is\n                     pressed.\n\n   :mouse-wheel    - Called every time mouse wheel is rotated.\n                     Takes 1 argument - wheel rotation, an int.\n                     Negative values if the mouse wheel was rotated\n                     up/away from the user, and positive values\n                     if the mouse wheel was rotated down/ towards the user\n\n   :key-pressed    - Called every time any key is pressed.\n\n   :key-released   - Called every time any key is released.\n\n   :key-typed      - Called once every time non-modifier keys are\n                     pressed.\n\n   :on-close       - Called once, when sketch is closed\n                     Not supported in ClojureScript.\n\n   :middleware     - Vector of middleware to be applied to the sketch.\n                     Middleware will be applied in the same order as in comp\n                     function: [f g] will be applied as (f (g options)).\n\n   :settings       - cousin of :setup. A function to be called once when\n                     setting sketch up. Should be used only for (smooth) and\n                     (no-smooth). Due to Processing limitations these functions\n                     cannot be used neither in :setup nor in :draw.",
   :what :macro},
  no-stroke
  {:args ({:value [], :type :both}),
@@ -1513,19 +1512,6 @@
   :docstring
   "Disables drawing the stroke (outline). If both no-stroke and\n  no-fill are called, nothing will be drawn to the screen.",
   :what :fn},
- end-camera
- {:args ({:value [], :type :both}),
-  :category "Lights, Camera",
-  :added "1.0",
-  :name end-camera,
-  :subcategory "Camera",
-  :type :both,
-  :processing-name "endCamera()",
-  :requires-bindings true,
-  :link "http://www.processing.org/reference/endCamera_.html",
-  :docstring
-  "Unsets the matrix mode from the camera matrix. See begin-camera.",
-  :what :fn},
  random-seed
  {:args ({:value [w], :type :both}),
   :category "Math",
@@ -1539,31 +1525,30 @@
   :docstring
   "Sets the seed value for random. By default, random produces\n  different results each time the program is run. Set the value\n  parameter to a constant to return the same pseudo-random numbers\n  each time the software is run.",
   :what :fn},
- model-z
- {:args ({:value [x y z], :type :both}),
-  :category "Lights, Camera",
-  :added "1.0",
-  :name model-z,
-  :subcategory "Coordinates",
-  :type :both,
-  :processing-name "modelZ()",
-  :requires-bindings true,
-  :link "http://www.processing.org/reference/modelZ_.html",
-  :docstring
-  "Returns the three-dimensional x, y, z position in model space. This\n  returns the z value for a given coordinate based on the current set\n  of transformations (scale, rotate, translate, etc.) The z value can\n  be used to place an object in space relative to the location of the\n  original point once the transformations are no longer in use.",
-  :what :fn},
  light-specular
- {:args ({:value [r g b], :type :both}),
+ {:args #{[r g b]},
   :category "Lights, Camera",
   :added "1.0",
   :name light-specular,
   :subcategory "Lights",
-  :type :both,
+  :type :clj,
   :processing-name "lightSpecular()",
   :requires-bindings true,
   :link "http://www.processing.org/reference/lightSpecular_.html",
   :docstring
-  "Sets the specular color for lights. Like fill, it affects only the\n  elements which are created after it in the code. Specular refers to\n  light which bounces off a surface in a perferred direction (rather\n  than bouncing in all directions like a diffuse light) and is used\n  for creating highlights. The specular quality of a light interacts\n  with the specular material qualities set through the specular and\n  shininess functions.",
+  "Sets the specular color for lights. Like fill, it affects only the\n  elements which are created after it in the code. Specular refers to\n  light which bounces off a surface in a preferred direction (rather\n  than bouncing in all directions like a diffuse light) and is used\n  for creating highlights. The specular quality of a light interacts\n  with the specular material qualities set through the specular and\n  shininess functions.",
+  :what :fn},
+ plane
+ {:args #{[width height]},
+  :category "Shape",
+  :added "3.0.0",
+  :name plane,
+  :subcategory "3D Primitives",
+  :type :cljs,
+  :processing-name "plane()",
+  :requires-bindings true,
+  :link "http://www.processing.org/reference/plane_.html",
+  :docstring "Draw a plane with given a width and height.",
   :what :fn},
  key-as-keyword
  {:args ({:value [], :type :both}),
@@ -1579,17 +1564,17 @@
   "Returns a keyword representing the currently pressed key. Modifier\n  keys are represented as: :up, :down, :left, :right, :alt, :control,\n  :shift, :command, :f1-24",
   :what :fn},
  blend-mode
- {:args #{[mode]},
+ {:args ({:value [mode], :type :both}),
   :category "Image",
   :added "2.0",
   :name blend-mode,
   :subcategory "Rendering",
-  :type :clj,
+  :type :both,
   :processing-name "blendMode()",
   :requires-bindings true,
   :link "http://www.processing.org/reference/blendMode_.html",
   :docstring
-  "Blends the pixels in the display window according to the defined mode.\n  There is a choice of the following modes to blend the source pixels (A)\n  with the ones of pixels already in the display window (B):\n\n  :blend      - linear interpolation of colours: C = A*factor + B\n  :add        - additive blending with white clip:\n                                            C = min(A*factor + B, 255)\n  :subtract   - subtractive blending with black clip:\n                                            C = max(B - A*factor, 0)\n  :darkest    - only the darkest colour succeeds:\n                                            C = min(A*factor, B)\n  :lightest   - only the lightest colour succeeds:\n                                            C = max(A*factor, B)\n  :exclusion  - similar to :difference, but less extreme.\n  :multiply   - Multiply the colors, result will always be darker.\n  :screen     - Opposite multiply, uses inverse values of the colors.\n  :replace    - the pixels entirely replace the others and don't utilize\n                alpha (transparency) values\n\n  Note: :hard-light, :soft-light, :dodge, :overlay, :dodge, :burn, :difference\n  modes are not supported by this function.\n\n  factor is alpha value of pixel being drawed",
+  "Blends the pixels in the display window according to the defined mode.\n  There is a choice of the following modes to blend the source pixels (A)\n  with the ones of pixels already in the display window (B):\n\n  :blend      - linear interpolation of colours: C = A*factor + B\n  :add        - additive blending with white clip:\n                                            C = min(A*factor + B, 255)\n  :subtract   - subtractive blending with black clip:\n                                            C = max(B - A*factor, 0)\n  :darkest    - only the darkest colour succeeds:\n                                            C = min(A*factor, B)\n  :lightest   - only the lightest colour succeeds:\n                                            C = max(A*factor, B)\n  :difference - subtract colors from underlying image.\n  :exclusion  - similar to :difference, but less extreme.\n  :multiply   - Multiply the colors, result will always be darker.\n  :screen     - Opposite multiply, uses inverse values of the colors.\n  :replace    - the pixels entirely replace the others and don't utilize\n                alpha (transparency) values.\n  :overlay    - mix of :multiply and :screen. Multiplies dark values,\n                and screens light values.\n  :hard-light - :screen when greater than 50% gray, :multiply when lower.\n  :soft-light - mix of :darkest and :lightest. Works like :overlay, but\n                not as harsh.\n  :dodge      - lightens light tones and increases contrast, ignores darks.\n  :burn       - darker areas are applied, increasing contrast, ignores\n                lights.\n\n  Note: in clj :hard-light, :soft-light, :overlay, :dodge, :burn\n  modes are not supported. In cljs :subtract mode is not supported.\n\n  factor is the alpha value of the pixel being drawn",
   :what :fn},
  dist
  {:args
@@ -1645,7 +1630,7 @@
   :requires-bindings true,
   :link "http://www.processing.org/reference/fill_.html",
   :docstring
-  "Sets the color used to fill shapes. For example, if you run fill(204, 102, 0),\n  all subsequent shapes will be filled with orange.  This function casts all input as a float.\n  If nil is passed it removes any fill color; equivalent to (no-fill).",
+  "Sets the color used to fill shapes. For example, if you run (fill 204 102 0),\n  all subsequent shapes will be filled with orange.  This function casts all input as a float.\n  If nil is passed it removes any fill color; equivalent to (no-fill).",
   :what :fn},
  with-translation
  {:args ({:value [translation-vector & body], :type :both}),
@@ -1674,17 +1659,18 @@
   "Replaces the current matrix with the identity matrix. The\n  equivalent function in OpenGL is glLoadIdentity()",
   :what :fn},
  mask-image
- {:args #{[img mask] [mask]},
+ {:args
+  ({:value [img mask], :type :both} {:value [mask], :type :both}),
   :category "Image",
   :added "1.0",
   :name mask-image,
   :subcategory "Loading & Displaying",
-  :type :clj,
+  :type :both,
   :processing-name "PImage.mask()",
   :requires-bindings false,
   :link "http://www.processing.org/reference/PImage_mask_.html",
   :docstring
-  "Masks part of an image from displaying by loading another image and\n  using it as an alpha channel.  This mask image should only contain\n  grayscale data, but only the blue color channel is used. The mask\n  image needs to be the same size as the image to which it is\n  applied.\n\n  If single argument function is used - masked image is sketch itself\n  or graphics if used inside with-graphics macro. If you're passing\n  graphics to this function - it works only with :p3d and :opengl renderers.\n\n  This method is useful for creating dynamically generated alpha\n  masks.",
+  "Masks part of an image from displaying by loading another image and\n  using it as an alpha channel.  This mask image should only contain\n  grayscale data. The mask image needs to be the same size as the image\n  to which it is applied.\n\n  If single argument function is used - masked image is sketch itself\n  or graphics if used inside with-graphics macro. If you're passing\n  graphics to this function - it works only with :p3d and :opengl renderers.\n\n  This method is useful for creating dynamically generated alpha\n  masks.",
   :what :fn},
  green
  {:args ({:value [col], :type :both}),
@@ -1766,12 +1752,12 @@
   "Returns the ascent of the current font at its current size. This\n  information is useful for determining the height of the font above\n  the baseline. For example, adding the text-ascent and text-descent\n  values will give you the total height of the line.",
   :what :fn},
  shininess
- {:args ({:value [shine], :type :both}),
+ {:args #{[shine]},
   :category "Lights, Camera",
   :added "1.0",
   :name shininess,
   :subcategory "Material Properties",
-  :type :both,
+  :type :clj,
   :processing-name "shininess()",
   :requires-bindings true,
   :link "http://www.processing.org/reference/shininess_.html",
@@ -1802,7 +1788,7 @@
   :requires-bindings true,
   :link "http://www.processing.org/reference/ellipseMode_.html",
   :docstring
-  "Modifies the origin of the ellispse according to the specified mode:\n\n  :center  - specifies the location of the ellipse as\n             the center of the shape. (Default).\n  :radius  - similar to center, but the width and height parameters to\n             ellipse specify the radius of the ellipse, rather than the\n             diameter.\n  :corner  - draws the shape from the upper-left corner of its bounding\n             box.\n  :corners - uses the four parameters to ellipse to set two opposing\n             corners of the ellipse's bounding box.",
+  "Modifies the origin of the ellipse according to the specified mode:\n\n  :center  - specifies the location of the ellipse as\n             the center of the shape. (Default).\n  :radius  - similar to center, but the width and height parameters to\n             ellipse specify the radius of the ellipse, rather than the\n             diameter.\n  :corner  - draws the shape from the upper-left corner of its bounding\n             box.\n  :corners - uses the four parameters to ellipse to set two opposing\n             corners of the ellipse's bounding box.",
   :what :fn},
  month
  {:args ({:value [], :type :both}),
@@ -1924,20 +1910,20 @@
   :requires-bindings true,
   :link "http://www.processing.org/reference/specular_.html",
   :docstring
-  "Sets the specular color of the materials used for shapes drawn to\n  the screen, which sets the color of hightlights. Specular refers to\n  light which bounces off a surface in a perferred direction (rather\n  than bouncing in all directions like a diffuse light). Used in\n  combination with emissive, ambient, and shininess in setting\n  the material properties of shapes.",
+  "Sets the specular color of the materials used for shapes drawn to\n  the screen, which sets the color of highlights. Specular refers to\n  light which bounces off a surface in a preferred direction (rather\n  than bouncing in all directions like a diffuse light). Used in\n  combination with emissive, ambient, and shininess in setting\n  the material properties of shapes.",
   :what :fn},
  save-frame
- {:args ({:value [], :type :both} {:value [name], :type :both}),
+ {:args #{[] [name]},
   :category "Output",
   :added "1.0",
   :name save-frame,
   :subcategory "Image",
-  :type :both,
+  :type :clj,
   :processing-name "saveFrame()",
   :requires-bindings true,
   :link "http://www.processing.org/reference/saveFrame_.html",
   :docstring
-  "Saves an image identical to the current display window as a\n  file. May be called multple times - each file saved will have a\n  unique name. Name and image formate may be modified by passing a\n  string parameter of the form \"foo-####.ext\" where foo- can be any\n  arbitrary string, #### will be replaced with the current frame id\n  and .ext is one of .tiff, .targa, .png, .jpeg or .jpg\n\n  Examples:\n  (save-frame)\n  (save-frame \"pretty-pic-####.jpg\")",
+  "Saves an image identical to the current display window as a\n  file. May be called multiple times - each file saved will have a\n  unique name. Name and image format may be modified by passing a\n  string parameter of the form \"foo-####.ext\" where foo- can be any\n  arbitrary string, #### will be replaced with the current frame id\n  and .ext is one of .tiff, .targa, .png, .jpeg or .jpg\n\n  Examples:\n  (save-frame)\n     (save-frame \"pretty-pic-####.jpg\")",
   :what :fn},
  cursor
  {:args ({:value [], :type :both} {:value [cursor-mode], :type :both}),
@@ -1950,7 +1936,7 @@
   :requires-bindings true,
   :link "http://www.processing.org/reference/cursor_.html",
   :docstring
-  "Sets the cursor to a predefined symbol or makes it\n  visible if already hidden (after no-cursor was called).\n\n  Available modes: :arrow, :cross, :hand, :move, :text, :wait\n\n  See cursor-image for specifying a generic image as the cursor\n  symbol.",
+  "Sets the cursor to a predefined symbol or makes it\n  visible if already hidden (after no-cursor was called).\n\n  Available modes: :arrow, :cross, :hand, :move, :text, :wait\n\n  See cursor-image for specifying a generic image as the cursor\n  symbol (clj only).",
   :what :fn},
  noise
  {:args
@@ -1997,12 +1983,12 @@
   "Specifies vertex coordinates for Bezier curves. Each call to\n  bezier-vertex defines the position of two control points and one\n  anchor point of a Bezier curve, adding a new segment to a line or\n  shape. The first time bezier-vertex is used within a begin-shape\n  call, it must be prefaced with a call to vertex to set the first\n  anchor point. This function must be used between begin-shape and\n  end-shape and only when there is no parameter specified to\n  begin-shape.",
   :what :fn},
  light-falloff
- {:args ({:value [constant linear quadratic], :type :both}),
+ {:args #{[constant linear quadratic]},
   :category "Lights, Camera",
   :added "1.0",
   :name light-falloff,
   :subcategory "Lights",
-  :type :both,
+  :type :clj,
   :processing-name "lightFalloff()",
   :requires-bindings true,
   :link "http://www.processing.org/reference/lightFalloff_.html",
@@ -2022,7 +2008,7 @@
   :requires-bindings true,
   :link "http://www.processing.org/reference/noiseDetail_.html",
   :docstring
-  "Adjusts the character and level of detail produced by the Perlin\n  noise function. Similar to harmonics in physics, noise is computed\n  over several octaves. Lower octaves contribute more to the output\n  signal and as such define the overal intensity of the noise, whereas\n  higher octaves create finer grained details in the noise\n  sequence. By default, noise is computed over 4 octaves with each\n  octave contributing exactly half than its predecessor, starting at\n  50% strength for the 1st octave. This falloff amount can be changed\n  by adding an additional function parameter. Eg. a falloff factor of\n  0.75 means each octave will now have 75% impact (25% less) of the\n  previous lower octave. Any value between 0.0 and 1.0 is valid,\n  however note that values greater than 0.5 might result in greater\n  than 1.0 values returned by noise.\n\n  By changing these parameters, the signal created by the noise\n  function can be adapted to fit very specific needs and\n  characteristics.",
+  "Adjusts the character and level of detail produced by the Perlin\n  noise function. Similar to harmonics in physics, noise is computed\n  over several octaves. Lower octaves contribute more to the output\n  signal and as such define the overall intensity of the noise, whereas\n  higher octaves create finer grained details in the noise\n  sequence. By default, noise is computed over 4 octaves with each\n  octave contributing exactly half than its predecessor, starting at\n  50% strength for the 1st octave. This falloff amount can be changed\n  by adding an additional function parameter. Eg. a falloff factor of\n  0.75 means each octave will now have 75% impact (25% less) of the\n  previous lower octave. Any value between 0.0 and 1.0 is valid,\n  however note that values greater than 0.5 might result in greater\n  than 1.0 values returned by noise.\n\n  By changing these parameters, the signal created by the noise\n  function can be adapted to fit very specific needs and\n  characteristics.",
   :what :fn},
  save
  {:args ({:value [filename], :type :both}),
@@ -2048,7 +2034,7 @@
   :requires-bindings true,
   :link "http://www.processing.org/reference/curvePoint_.html",
   :docstring
-  "Evalutes the curve at point t for points a, b, c, d. The parameter\n  t varies between 0 and 1, a and d are points on the curve, and b c\n  and are the control points. This can be done once with the x\n  coordinates and a second time with the y coordinates to get the\n  location of a curve at t.",
+  "Evaluates the curve at point t for points a, b, c, d. The parameter\n  t varies between 0 and 1, a and d are points on the curve, and b c\n  and are the control points. This can be done once with the x\n  coordinates and a second time with the y coordinates to get the\n  location of a curve at t.",
   :what :fn},
  state
  {:args ({:value [], :type :both} {:value [key], :type :both}),
@@ -2075,7 +2061,7 @@
   :requires-bindings true,
   :link "http://www.processing.org/reference/loadShader_.html",
   :docstring
-  "Loads a shader into the PShader object. Shaders are compatible with the\n  P2D and P3D renderers, but not with the default renderer.",
+  "Loads a shader into the PShader object for clj and Shader object for\n  cljs. In clj mode shaders are\n  compatible with the P2D and P3D renderers, but not with the default\n  renderer. In cljs mode shaders are compatible with the P3D renderer.",
   :what :fn},
  resize
  {:args ({:value [img w h], :type :both}),
@@ -2090,19 +2076,6 @@
   :link "http://processing.org/reference/PImage_resize_.html",
   :docstring
   "Resize the image to a new width and height.\n  To make the image scale proportionally, use 0 as the value for the wide or\n  high parameter. For instance, to make the width of an image 150 pixels,\n  and change the height using the same proportion, use resize(150, 0).\n\n  Even though a PGraphics is technically a PImage, it is not possible\n  to rescale the image data found in a PGraphics.\n  (It's simply not possible to do this consistently across renderers:\n  technically infeasible with P3D, or what would it even do with PDF?)\n  If you want to resize PGraphics content, first get a copy of its image data\n  using the get() method, and call resize() on the PImage that is returned.",
-  :what :fn},
- normal
- {:args ({:value [nx ny nz], :type :both}),
-  :category "Lights, Camera",
-  :added "1.0",
-  :name normal,
-  :subcategory "Lights",
-  :type :both,
-  :processing-name "normal()",
-  :requires-bindings true,
-  :link "http://www.processing.org/reference/normal_.html",
-  :docstring
-  "Sets the current normal vector. This is for drawing three\n  dimensional shapes and surfaces and specifies a vector perpendicular\n  to the surface of the shape which determines how lighting affects\n  it. Processing attempts to automatically assign normals to shapes,\n  but since that's imperfect, this is a better option when you want\n  more control. This function is identical to glNormal3f() in OpenGL.",
   :what :fn},
  perspective
  {:args
@@ -2132,12 +2105,12 @@
   :docstring "Returns the current second as a value from 0 - 59.",
   :what :fn},
  hint
- {:args ({:value [hint-type], :type :both}),
+ {:args #{[hint-type]},
   :category "Rendering",
   :added "1.0",
   :name hint,
   :subcategory nil,
-  :type :both,
+  :type :clj,
   :processing-name "hint()",
   :processing-link nil,
   :requires-bindings true,
@@ -2146,18 +2119,17 @@
   "Set various hints and hacks for the renderer. This is used to\n  handle obscure rendering features that cannot be implemented in a\n  consistent manner across renderers. Many options will often graduate\n  to standard features instead of hints over time.\n\n  Options:\n\n  :enable-native-fonts - Use the native version fonts when they are\n    installed, rather than the bitmapped version from a .vlw\n    file. This is useful with the default (or JAVA2D) renderer\n    setting, as it will improve font rendering speed. This is not\n    enabled by default, because it can be misleading while testing\n    because the type will look great on your machine (because you have\n    the font installed) but lousy on others' machines if the identical\n    font is unavailable. This option can only be set per-sketch, and\n    must be called before any use of text-font.\n\n  :disable-native-fonts - Disables native font support.\n\n  :disable-depth-test - Disable the zbuffer, allowing you to draw on\n    top of everything at will. When depth testing is disabled, items\n    will be drawn to the screen sequentially, like a painting. This\n    hint is most often used to draw in 3D, then draw in 2D on top of\n    it (for instance, to draw GUI controls in 2D on top of a 3D\n    interface). Starting in release 0149, this will also clear the\n    depth buffer. Restore the default with :enable-depth-test\n    but note that with the depth buffer cleared, any 3D drawing that\n    happens later in draw will ignore existing shapes on the screen.\n\n  :enable-depth-test - Enables the zbuffer.\n\n  :enable-depth-sort - Enable primitive z-sorting of triangles and\n    lines in :p3d and :opengl rendering modes. This can slow\n    performance considerably, and the algorithm is not yet perfect.\n\n  :disable-depth-sort - Disables hint :enable-depth-sort\n\n  :disable-opengl-errors - Speeds up the OPENGL renderer setting\n     by not checking for errors while running.\n\n  :enable-opengl-errors - Turns on OpenGL error checking\n\n  :enable-depth-mask\n  :disable-depth-mask\n\n  :enable-optimized-stroke\n  :disable-optimized-stroke\n  :enable-retina-pixels\n  :disable-retina-pixels\n  :enable-stroke-perspective\n  :disable-stroke-perspective\n  :enable-stroke-pure\n  :disable-stroke-pure\n  :enable-texture-mipmaps\n  :disable-texture-mipmaps\n",
   :what :fn},
  sphere-detail
- {:args
-  ({:value [ures vres], :type :both} {:value [res], :type :both}),
+ {:args #{[ures vres] [res]},
   :category "Shape",
   :added "1.0",
   :name sphere-detail,
   :subcategory "3D Primitives",
-  :type :both,
+  :type :clj,
   :processing-name "sphereDetail()",
   :requires-bindings true,
   :link "http://www.processing.org/reference/sphereDetail_.html",
   :docstring
-  "Controls the detail used to render a sphere by adjusting the number\n  of vertices of the sphere mesh. The default resolution is 30, which\n  creates a fairly detailed sphere definition with vertices every\n  360/30 = 12 degrees. If you're going to render a great number of\n  spheres per frame, it is advised to reduce the level of detail using\n  this function. The setting stays active until sphere-detail is\n  called again with a new parameter and so should not be called prior\n  to every sphere statement, unless you wish to render spheres with\n  different settings, e.g. using less detail for smaller spheres or\n  ones further away from the camera. To controla the detail of the\n  horizontal and vertical resolution independently, use the version of\n  the functions with two parameters.",
+  "Controls the detail used to render a sphere by adjusting the number\n  of vertices of the sphere mesh. The default resolution is 30, which\n  creates a fairly detailed sphere definition with vertices every\n  360/30 = 12 degrees. If you're going to render a great number of\n  spheres per frame, it is advised to reduce the level of detail using\n  this function. The setting stays active until sphere-detail is\n  called again with a new parameter and so should not be called prior\n  to every sphere statement, unless you wish to render spheres with\n  different settings, e.g. using less detail for smaller spheres or\n  ones further away from the camera. To control the detail of the\n  horizontal and vertical resolution independently, use the version of\n  the functions with two parameters.",
   :what :fn},
  vertex
  {:args
@@ -2177,29 +2149,28 @@
   "All shapes are constructed by connecting a series of\n  vertices. vertex is used to specify the vertex coordinates for\n  points, lines, triangles, quads, and polygons and is used\n  exclusively within the begin-shape and end-shape fns.\n\n  Drawing a vertex in 3D using the z parameter requires the :p3d or\n  :opengl renderers to be used.\n\n  This function is also used to map a texture onto the geometry. The\n  texture fn declares the texture to apply to the geometry and the u\n  and v coordinates set define the mapping of this texture to the\n  form. By default, the coordinates used for u and v are specified in\n  relation to the image's size in pixels, but this relation can be\n  changed with texture-mode.",
   :what :fn},
  delay-frame
- {:args ({:value [freeze-ms], :type :both}),
+ {:args #{[freeze-ms]},
   :category "Structure",
   :added "1.0",
   :name delay-frame,
   :subcategory nil,
-  :type :both,
+  :type :clj,
   :processing-name "delay()",
   :processing-link nil,
   :requires-bindings true,
   :link nil,
   :docstring
-  "Forces the program to stop running for a specified time. Delay\n  times are specified in thousandths of a second, therefore the\n  function call (delay 3000) will stop the program for three\n  seconds. Because the screen is updated only at the end of draw,\n  the program may appear to 'freeze', because the screen will not\n  update when the delay fn is used. This function has no affect\n  inside setup.",
+  "Forces the program to stop running for a specified time. Delay\n     times are specified in thousandths of a second, therefore the\n     function call (delay 3000) will stop the program for three\n     seconds. Because the screen is updated only at the end of draw,\n     the program may appear to 'freeze', because the screen will not\n     update when the delay fn is used. This function has no affect\n     inside setup.",
   :what :fn},
  spot-light
  {:args
-  ({:value [r g b x y z nx ny nz angle concentration], :type :both}
-   {:value [[r g b] [x y z] [nx ny nz] angle concentration],
-    :type :both}),
+  #{[r g b x y z nx ny nz angle concentration]
+    [[r g b] [x y z] [nx ny nz] angle concentration]},
   :category "Lights, Camera",
   :added "1.0",
   :name spot-light,
   :subcategory "Lights",
-  :type :both,
+  :type :clj,
   :processing-name "spotLight()",
   :requires-bindings true,
   :link "http://www.processing.org/reference/spotLight_.html",
@@ -2286,19 +2257,6 @@
   :docstring
   "Converts a String representation of a hexadecimal number to its\n  equivalent integer value.",
   :what :fn},
- begin-camera
- {:args ({:value [], :type :both}),
-  :category "Lights, Camera",
-  :added "1.0",
-  :name begin-camera,
-  :subcategory "Camera",
-  :type :both,
-  :processing-name "beginCamera()",
-  :requires-bindings true,
-  :link "http://www.processing.org/reference/beginCamera_.html",
-  :docstring
-  "Sets the matrix mode to the camera matrix so calls such as\n  translate, rotate, apply-matrix and reset-matrix affect the\n  camera. begin-camera should always be used with a following\n  end-camera and pairs of begin-camera and end-camera cannot be\n  nested.\n\n  For most situations the camera function will be sufficient.",
-  :what :fn},
  text-num
  {:args
   ({:value [num x y], :type :both} {:value [num x y z], :type :both}),
@@ -2349,21 +2307,22 @@
   :processing-name "loadShape()",
   :requires-bindings true,
   :link "http://www.processing.org/reference/loadShape_.html",
-  :docstring "Load a geometry from a file as a PShape.",
+  :docstring
+  "Load a geometry from a file as a PShape in clj, and a Geometry\n  in cljs.",
   :what :fn},
  blend-color
- {:args ({:value [c1 c2 mode], :type :both}),
+ {:args #{[c1 c2 mode]},
   :category "Color",
   :added "1.0",
   :name blend-color,
   :subcategory "Creating & Reading",
-  :type :both,
+  :type :clj,
   :processing-name "blendColor()",
   :processing-link nil,
   :requires-bindings false,
   :link nil,
   :docstring
-  "Blends two color values together based on the blending mode given specified\n  with the mode keyword.\n\n  Available blend modes are:\n\n  :blend      - linear interpolation of colours: C = A*factor + B\n  :add        - additive blending with white clip:\n                                            C = min(A*factor + B, 255)\n  :subtract   - subtractive blending with black clip:\n                                            C = max(B - A*factor, 0)\n  :darkest    - only the darkest colour succeeds:\n                                            C = min(A*factor, B)\n  :lightest   - only the lightest colour succeeds:\n                                            C = max(A*factor, B)\n  :difference - subtract colors from underlying image.\n  :exclusion  - similar to :difference, but less extreme.\n  :multiply   - Multiply the colors, result will always be darker.\n  :screen     - Opposite multiply, uses inverse values of the colors.\n  :overlay    - A mix of :multiply and :screen. Multiplies dark values\n                and screens light values.\n  :hard-light - :screen when greater than 50% gray, :multiply when\n                lower.\n  :soft-light - Mix of :darkest and :lightest. Works like :overlay,\n                but not as harsh.\n  :dodge      - Lightens light tones and increases contrast, ignores\n                darks.\n                Called \"Color Dodge\" in Illustrator and Photoshop.\n  :burn       - Darker areas are applied, increasing contrast, ignores\n                lights. Called \"Color Burn\" in Illustrator and\n                Photoshop.",
+  "Blends two color values together based on the blending mode given specified\n     with the mode keyword.\n\n     Available blend modes are:\n\n     :blend      - linear interpolation of colours: C = A*factor + B\n     :add        - additive blending with white clip:\n                                               C = min(A*factor + B, 255)\n     :subtract   - subtractive blending with black clip:\n                                               C = max(B - A*factor, 0)\n     :darkest    - only the darkest colour succeeds:\n                                               C = min(A*factor, B)\n     :lightest   - only the lightest colour succeeds:\n                                               C = max(A*factor, B)\n     :difference - subtract colors from underlying image.\n     :exclusion  - similar to :difference, but less extreme.\n     :multiply   - Multiply the colors, result will always be darker.\n     :screen     - Opposite multiply, uses inverse values of the colors.\n     :overlay    - A mix of :multiply and :screen. Multiplies dark values\n                   and screens light values.\n     :hard-light - :screen when greater than 50% gray, :multiply when\n                   lower.\n     :soft-light - Mix of :darkest and :lightest. Works like :overlay,\n                   but not as harsh.\n     :dodge      - Lightens light tones and increases contrast, ignores\n                   darks.\n                   Called \"Color Dodge\" in Illustrator and Photoshop.\n     :burn       - Darker areas are applied, increasing contrast, ignores\n                   lights. Called \"Color Burn\" in Illustrator and\n                   Photoshop.",
   :what :fn},
  texture-wrap
  {:args #{[mode]},
@@ -2424,7 +2383,7 @@
   :args ({:value [width height], :type :both}),
   :name resize-sketch,
   :docstring
-  "Resizes sketch.\n  Note about ClojureScript version: if canvas element is resized by external\n  reasons (for example from js on a page then you still need to call this\n  method in order to tell Quil that size has changed. Currently there is no\n  good way to automatically detect that size of <canvas> element changed.",
+  "Resizes sketch.\n  Note about ClojureScript version: if div element is resized by external\n  reasons (for example from js on a page then you still need to call this\n  method in order to tell Quil that size has changed. Currently there is no\n  good way to automatically detect that size of <div> element changed.",
   :what :fn,
   :link nil,
   :type :both},
@@ -2505,6 +2464,21 @@
   :docstring
   "Temporarily set the fill color for the body of this macro.\n   The code outside of with-fill form will have the previous fill color set.\n\n   A fill argument of nil disables the fill.\n\n   Example: (with-fill 255 ...)\n            (with-fill [10 80 98] ...)\n            (with-fill nil ...)",
   :what :macro},
+ ellipsoid
+ {:args
+  #{[radius-x radius-y radius-z] [radius-x radius-y radius-z detail-x]
+    [radius-x radius-y radius-z detail-x detail-y]},
+  :category "Shape",
+  :added "3.0.0",
+  :name ellipsoid,
+  :subcategory "3D Primitives",
+  :type :cljs,
+  :processing-name "ellipsoid()",
+  :requires-bindings true,
+  :link "http://www.processing.org/reference/ellipsoid_.html",
+  :docstring
+  "Draw an ellipsoid with given radius\n       Optional parameters:\n         detail-x: number of segments, the more segments the smoother geometry default is 24\n         detail-y: number of segments, the more segments the smoother geometry default is 16",
+  :what :fn},
  no-cursor
  {:args ({:value [], :type :both}),
   :category "Environment",
@@ -2519,20 +2493,17 @@
   "Hides the cursor from view. Will not work when running the in full\n  screen (Present) mode.",
   :what :fn},
  create-font
- {:args
-  ({:value [name size smooth charset], :type :both}
-   {:value [name size smooth], :type :both}
-   {:value [name size], :type :both}),
+ {:args #{[name size smooth charset] [name size smooth] [name size]},
   :category "Typography",
   :added "1.0",
   :name create-font,
   :subcategory "Loading & Displaying",
-  :type :both,
+  :type :clj,
   :processing-name "createFont()",
   :requires-bindings true,
   :link "http://www.processing.org/reference/createFont_.html",
   :docstring
-  "Dynamically converts a font to the format used by Processing (a\n  PFont) from either a font name that's installed on the computer, or\n  from a .ttf or .otf file inside the sketches 'data' folder. This\n  function is an advanced feature for precise control.\n\n  Use available-fonts to obtain the names for the fonts recognized by\n  the computer and are compatible with this function.\n\n  The size parameter states the font size you want to generate. The\n  smooth parameter specifies if the font should be antialiased or not,\n  and the charset parameter is an array of chars that specifies the\n  characters to generate.\n\n  This function creates a bitmapped version of a font It loads a font\n  by name, and converts it to a series of images based on the size of\n  the font. When possible, the text function will use a native font\n  rather than the bitmapped version created behind the scenes with\n  create-font. For instance, when using the default renderer\n  setting (JAVA2D), the actual native version of the font will be\n  employed by the sketch, improving drawing quality and\n  performance. With the :p2d, :p3d, and :opengl renderer settings, the\n  bitmapped version will be used. While this can drastically improve\n  speed and appearance, results are poor when exporting if the sketch\n  does not include the .otf or .ttf file, and the requested font is\n  not available on the machine running the sketch.",
+  "Dynamically converts a font to the format used by Processing (a\n     PFont) from either a font name that's installed on the computer, or\n     from a .ttf or .otf file inside the sketches 'data' folder. This\n     function is an advanced feature for precise control.\n\n     Use available-fonts to obtain the names for the fonts recognized by\n     the computer and are compatible with this function.\n\n     The size parameter states the font size you want to generate. The\n     smooth parameter specifies if the font should be antialiased or not,\n     and the charset parameter is an array of chars that specifies the\n     characters to generate.\n\n     This function creates a bitmapped version of a font It loads a font\n     by name, and converts it to a series of images based on the size of\n     the font. When possible, the text function will use a native font\n     rather than the bitmapped version created behind the scenes with\n     create-font. For instance, when using the default renderer\n     setting (JAVA2D), the actual native version of the font will be\n     employed by the sketch, improving drawing quality and\n     performance. With the :p2d, :p3d, and :opengl renderer settings, the\n     bitmapped version will be used. While this can drastically improve\n     speed and appearance, results are poor when exporting if the sketch\n     does not include the .otf or .ttf file, and the requested font is\n     not available on the machine running the sketch.",
   :what :fn},
  current-graphics
  {:args ({:value [], :type :both}),
@@ -2587,17 +2558,32 @@
   "Returns a boolean value representing whether the applet has focus.",
   :what :fn},
  text-mode
- {:args ({:value [mode], :type :both}),
+ {:args #{[mode]},
   :category "Typography",
   :added "1.0",
   :name text-mode,
   :subcategory "Attributes",
-  :type :both,
+  :type :clj,
   :processing-name "textMode()",
   :requires-bindings true,
   :link "http://www.processing.org/reference/textMode_.html",
   :docstring
-  "Sets the way text draws to the screen - available modes\n  are :model and :shape\n\n  In the default configuration (the :model mode), it's possible to\n  rotate, scale, and place letters in two and three dimensional space.\n\n  The :shape mode draws text using the glyph outlines of individual\n  characters rather than as textures. This mode is only supported with\n  the PDF and OPENGL renderer settings. With the PDF renderer, you\n  must specify the :shape text-mode before any other drawing occurs.\n  If the outlines are not available, then :shape will be ignored and\n  :model will be used instead.\n\n  The :shape option in OPENGL mode can be combined with begin-raw to\n  write vector-accurate text to 2D and 3D output files, for instance\n  DXF or PDF. :shape is not currently optimized for OPENGL, so if\n  recording shape data, use :model until you're ready to capture the\n  geometry with begin-raw.",
+  "Sets the way text draws to the screen - available modes\n     are :model and :shape\n\n     In the default configuration (the :model mode), it's possible to\n     rotate, scale, and place letters in two and three dimensional space.\n\n     The :shape mode draws text using the glyph outlines of individual\n     characters rather than as textures. This mode is only supported with\n     the PDF and OPENGL renderer settings. With the PDF renderer, you\n     must specify the :shape text-mode before any other drawing occurs.\n     If the outlines are not available, then :shape will be ignored and\n     :model will be used instead.\n\n     The :shape option in OPENGL mode can be combined with begin-raw to\n     write vector-accurate text to 2D and 3D output files, for instance\n     DXF or PDF. :shape is not currently optimized for OPENGL, so if\n     recording shape data, use :model until you're ready to capture the\n     geometry with begin-raw.",
+  :what :fn},
+ torus
+ {:args
+  #{[radius tube-radius] [radius tube-radius detail-x]
+    [radius tube-radius detail-x detail-y]},
+  :category "Shape",
+  :added "3.0.0",
+  :name torus,
+  :subcategory "3D Primitives",
+  :type :cljs,
+  :processing-name "torus()",
+  :requires-bindings true,
+  :link "http://www.processing.org/reference/torus_.html",
+  :docstring
+  "Draw a torus with given radius and tube radius.\n      Optional parameters:\n        detail-x: number of segments, the more segments the smoother geometry default is 24\n        detail-y: number of segments, the more segments the smoother geometry default is 16",
   :what :fn},
  image-mode
  {:args ({:value [mode], :type :both}),
@@ -2626,7 +2612,7 @@
   :requires-bindings true,
   :link "http://www.processing.org/reference/line_.html",
   :docstring
-  "Draws a line (a direct path between two points) to the screen. The\n  version of line with four parameters draws the line in 2D. To color\n  a line, use the stroke function. A line cannot be filled, therefore\n  the fill method will not affect the color of a line. 2D lines are\n  drawn with a width of one pixel by default, but this can be changed\n  with the stroke-weight function. The version with six parameters\n  allows the line to be placed anywhere within XYZ space. ",
+  "Draws a line (a direct path between two points) to the screen. The\n  version of line with four parameters draws the line in 2D. To color\n  a line, use the stroke function. A line cannot be filled, therefore\n  the fill method will not affect the color of a line. 2D lines are\n  drawn with a width of one pixel by default, but this can be changed\n  with the stroke-weight function. The version with six parameters\n  allows the line to be placed anywhere within XYZ space.",
   :what :fn},
  do-record
  {:args ({:value [graphics & body], :type :both}),
@@ -2682,17 +2668,17 @@
   "Extracts the blue value from a color, scaled to match current color-mode.\n  Returns a float.",
   :what :fn},
  frustum
- {:args ({:value [left right bottom top near far], :type :both}),
+ {:args #{[left right bottom top near far]},
   :category "Lights, Camera",
   :added "1.0",
   :name frustum,
   :subcategory "Camera",
-  :type :both,
+  :type :clj,
   :processing-name "frustum()",
   :requires-bindings true,
   :link "http://www.processing.org/reference/frustum_.html",
   :docstring
-  "Sets a perspective matrix defined through the parameters. Works\n  like glFrustum, except it wipes out the current perspective matrix\n  rather than muliplying itself with it.",
+  "Sets a perspective matrix defined through the parameters. Works\n  like glFrustum, except it wipes out the current perspective matrix\n  rather than multiplying itself with it.\n  https://en.wikipedia.org/wiki/Frustum",
   :what :fn},
  with-rotation
  {:args ({:value [rotation & body], :type :both}),
@@ -2708,12 +2694,12 @@
   "Performs body with rotation, restores current transformation on exit.\n  Accepts a vector [angle] or [angle x y z].\n\n  When 4 arguments provides it produces a rotation of angle degrees\n  around the vector x y z. Check examples for to better understand.\n  This rotation follows the right-hand rule, so if the vector x y z points\n  toward the user, the rotation will be counterclockwise.\n\n  Example:\n    (with-rotation [angle]\n      (vertex 1 2))",
   :what :macro},
  print-matrix
- {:args ({:value [], :type :both}),
+ {:args #{[]},
   :category "Transform",
   :added "1.0",
   :name print-matrix,
   :subcategory nil,
-  :type :both,
+  :type :clj,
   :processing-name "printMatrix()",
   :requires-bindings true,
   :link "http://www.processing.org/reference/printMatrix_.html",
@@ -2761,18 +2747,18 @@
   :docstring
   "A quad is a quadrilateral, a four sided polygon. It is similar to a\n  rectangle, but the angles between its edges are not constrained to\n  be ninety degrees. The first pair of parameters (x1,y1) sets the\n  first vertex and the subsequent pairs should proceed clockwise or\n  counter-clockwise around the defined shape.",
   :what :fn},
- screen-x
- {:args ({:value [x y], :type :both} {:value [x y z], :type :both}),
-  :category "Lights, Camera",
-  :added "1.0",
-  :name screen-x,
-  :subcategory "Coordinates",
-  :type :both,
-  :processing-name "screenX()",
+ text-style
+ {:args #{[style]},
+  :category "Typography",
+  :added "2.8.0",
+  :name text-style,
+  :subcategory "Attributes",
+  :type :cljs,
+  :processing-name "textStyle()",
   :requires-bindings true,
-  :link "http://www.processing.org/reference/screenX_.html",
+  :link "http://www.processing.org/reference/textStyle_.html",
   :docstring
-  "Takes a three-dimensional x, y, z position and returns the x value\n  for where it will appear on a (two-dimensional) screen, once\n  affected by translate, scale or any other transformations",
+  "Sets/gets the style of the text for system fonts to :normal, :italic,\n     or :bold. Note: this may be is overridden by CSS styling. For\n     non-system fonts (opentype, truetype, etc.) please load styled fonts\n     instead.",
   :what :fn},
  navigation-3d
  {:args ({:value [options], :type :both}),
@@ -2788,17 +2774,31 @@
   "Enables navigation in 3D space. Similar to how it is done in\n  shooters: WASD navigation, space is go up, drag mouse to look around.\n  This middleware requires fun-mode.\n\n\n  Navigation\n\n  * Drag mouse to look around. You can change settings to bind\n    mouse-moved instead of mouse-dragged to look around. See\n    customization info below.\n\n  * Keyboard:\n    * w - go forward\n    * s - go backward\n    * a - strafe left\n    * d - strafe right\n    * space - go up\n    * z - go down, can't bind to ctrl, limitation of Processing\n\n\n  Customization\n\n  You can customize this middleware by providing map as\n  :navigation-3d option in defsketch/sketch. Map can have following\n  optional keys:\n\n  :position - vector of 3 numbers, initial camera position. Default\n              is the same as in 'camera' function.\n\n  :straight - vector of 3 numbers, direction you'll be looking at.\n              Default is [0 0 -1] (looking down).\n\n  :up - vector of 3 numbers, 'up' direction. Default is [0 1 0].\n\n  :pixels-in-360 - number, mouse sensitivity. Defines how many pixels\n                   you need to move/drag you mouse to rotate 360 degrees.\n                   The less the number the more sensitive is mouse.\n                   Default is 1000.\n\n  :step-size - number, number of pixels you move on each key event (wasd).\n               Default is 20.\n\n  :rotate-on - keyword, either :mouse-dragged or :mouse-moved. Specifies\n               on which mouse event camera should rotate. Default is\n               :mouse-dragged.\n\n\n  Accessing position information from sketch\n\n  navigation-3d uses fun-mode under the hood  so all position-related\n  information is stored in the state map. It means that you can access in\n  draw/update/any handler and modify it if you need to. Position\n  information is a map which is stored under :navigation-3d key in the\n  state map. Position consists of 3 values: :position, :straight and :up.\n  See \"Customization\" section above for more details.\n\n  Usage example:\n\n  (q/defsketch my-sketch\n    ...\n    :middleware [m/fun-mode m/navigation-3d])\n\n  See wiki article for more(?) details:\n  https://github.com/quil/quil/wiki/Navigation-3D",
   :what :fn},
  lights
- {:args ({:value [], :type :both}),
+ {:args #{[]},
   :category "Lights, Camera",
   :added "1.0",
   :name lights,
   :subcategory "Lights",
-  :type :both,
+  :type :clj,
   :processing-name "lights()",
   :requires-bindings true,
   :link "http://www.processing.org/reference/lights_.html",
   :docstring
   "Sets the default ambient light, directional light, falloff, and\n  specular values. The defaults are:\n\n  (ambient-light 128 128 128)\n  (directional-light 128 128 128 0 0 -1)\n  (light-falloff 1 0 0)\n  (light-specular 0 0 0).\n\n  Lights need to be included in the draw to remain persistent in a\n  looping program. Placing them in the setup of a looping program\n  will cause them to only have an effect the first time through the\n  loop.",
+  :what :fn},
+ cylinder
+ {:args
+  #{[radius height]
+    [radius height detail-x detail-y bottom-cap top-cap]},
+  :category "Shape",
+  :added "3.0.0",
+  :name cylinder,
+  :subcategory "3D Primitives",
+  :type :cljs,
+  :processing-name "cylinder()",
+  :requires-bindings true,
+  :link "http://www.processing.org/reference/cylinder_.html",
+  :docstring "Draw a cylinder with given radius and height.",
   :what :fn},
  looping?
  {:args ({:value [], :type :both}),
@@ -2876,6 +2876,34 @@
   :docstring
   "Calculates the sine of an angle. This function expects the values\n  of the angle parameter to be provided in radians (values from 0 to\n  6.28). A float within the range -1 to 1 is returned.",
   :what :fn},
+ cone
+ {:args
+  #{[radius height] [radius height detail-x detail-y]
+    [radius height detail-x detail-y cap] [radius height detail-x]},
+  :category "Shape",
+  :added "3.0.0",
+  :name cone,
+  :subcategory "3D Primitives",
+  :type :cljs,
+  :processing-name "cone()",
+  :requires-bindings true,
+  :link "http://www.processing.org/reference/cone_.html",
+  :docstring
+  "Draw a cone with given radius and height.\n      Optional parameters:\n        detail-x: number of segments, the more segments the smoother geometry default is 24\n        detail-y: number of segments, the more segments the smoother geometry default is 24\n        cap:      whether to draw the base of the cone",
+  :what :fn},
+ lightness
+ {:args #{[c]},
+  :category "Color",
+  :added "3.0.0",
+  :name lightness,
+  :subcategory "Creating & Reading",
+  :type :cljs,
+  :processing-name "lightness()",
+  :requires-bindings true,
+  :link "http://www.processing.org/reference/lightness_.html",
+  :docstring
+  "Extracts the HSL lightness value from a color or pixel array.",
+  :what :fn},
  current-stroke
  {:args ({:value [], :type :both}),
   :category "Color",
@@ -2907,8 +2935,8 @@
   :what :fn},
  shape
  {:args
-  ({:value [sh x y width height], :type :both}
-   {:value [sh x y], :type :both}
+  ({:value [sh x y width height], :type :clj}
+   {:value [sh x y], :type :clj}
    {:value [sh], :type :both}),
   :category "Shape",
   :added "1.0",
@@ -2933,19 +2961,6 @@
   :link "http://www.processing.org/reference/textDescent_.html",
   :docstring
   "Returns descent of the current font at its current size. This\n  information is useful for determining the height of the font below\n  the baseline. For example, adding the text-ascent and text-descent\n  values will give you the total height of the line.",
-  :what :fn},
- screen-z
- {:args ({:value [x y z], :type :both}),
-  :category "Lights, Camera",
-  :added "1.0",
-  :name screen-z,
-  :subcategory "Coordinates",
-  :type :both,
-  :processing-name "screenZ()",
-  :requires-bindings true,
-  :link "http://www.processing.org/reference/screenZ_.html",
-  :docstring
-  "Given an x, y, z coordinate, returns its z value.\n   This value can be used to determine if an x, y, z coordinate is in\n   front or in back of another (x, y, z) coordinate. The units are\n   based on how the zbuffer is set up, and don't relate to anything\n   'real'. They're only useful for in comparison to another value\n   obtained from screen-z, or directly out of the zbuffer",
   :what :fn},
  ellipse
  {:args ({:value [x y width height], :type :both}),
@@ -2986,7 +3001,7 @@
   :requires-bindings true,
   :link "http://www.processing.org/reference/PImage_filter_.html",
   :docstring
-  "Originally named filter in Processing Language.\n  Filters given image with the specified mode and level.\n  Level defines the quality of the filter and mode may be one of\n  the following keywords:\n\n  :threshold - converts the image to black and white pixels depending\n               if they are above or below the threshold defined by\n               the level parameter. The level must be between\n               0.0 (black) and 1.0 (white). If no level is specified,\n               0.5 is used.\n  :gray      - converts any colors in the image to grayscale\n               equivalents. Doesn't work with level.\n  :invert    - sets each pixel to its inverse value. Doesn't work with\n               level.\n  :posterize - limits each channel of the image to the number of\n               colors specified as the level parameter. The parameter can\n               be set to values between 2 and 255, but results are most\n               noticeable in the lower ranges.\n  :blur      - executes a Guassian blur with the level parameter\n               specifying the extent of the blurring. If no level\n               parameter is used, the blur is equivalent to Guassian\n               blur of radius 1.\n  :opaque    - sets the alpha channel to entirely opaque. Doesn't work\n               with level.\n  :erode     - reduces the light areas. Doesn't work with level.\n  :dilate    - increases the light areas.  Doesn't work with level.",
+  "Originally named filter in Processing Language.\n  Filters given image with the specified mode and level.\n  Level defines the quality of the filter and mode may be one of\n  the following keywords:\n\n  :threshold - converts the image to black and white pixels depending\n               if they are above or below the threshold defined by\n               the level parameter. The level must be between\n               0.0 (black) and 1.0 (white). If no level is specified,\n               0.5 is used.\n  :gray      - converts any colors in the image to grayscale\n               equivalents. Doesn't work with level.\n  :invert    - sets each pixel to its inverse value. Doesn't work with\n               level.\n  :posterize - limits each channel of the image to the number of\n               colors specified as the level parameter. The parameter can\n               be set to values between 2 and 255, but results are most\n               noticeable in the lower ranges.\n  :blur      - executes a Gaussian blur with the level parameter\n               specifying the extent of the blurring. If no level\n               parameter is used, the blur is equivalent to Gaussian\n               blur of radius 1.\n  :opaque    - sets the alpha channel to entirely opaque. Doesn't work\n               with level.\n  :erode     - reduces the light areas. Doesn't work with level.\n  :dilate    - increases the light areas.  Doesn't work with level.",
   :what :fn},
  random
  {:args ({:value [max], :type :both} {:value [min max], :type :both}),
@@ -3002,12 +3017,12 @@
   "Generates random numbers. Each time the random function is called,\n  it returns an unexpected value within the specified range. If one\n  parameter is passed to the function it will return a float between\n  zero and the value of the high parameter. The function call (random\n  5) returns values between 0 and 5 (starting at zero, up to but not\n  including 5). If two parameters are passed, it will return a float\n  with a value between the parameters. The function call\n  (random -5 10.2) returns values starting at -5 up to (but not\n  including) 10.2.",
   :what :fn},
  texture-mode
- {:args ({:value [mode], :type :both}),
+ {:args #{[mode]},
   :category "Shape",
   :added "1.0",
   :name texture-mode,
   :subcategory "Vertex",
-  :type :both,
+  :type :clj,
   :processing-name "textureMode()",
   :requires-bindings true,
   :link "http://www.processing.org/reference/textureMode_.html",
@@ -3015,7 +3030,7 @@
   "Sets the coordinate space for texture mapping. There are two\n  options, :image and :normal.\n\n  :image refers to the actual coordinates of the image and :normal\n  refers to a normalized space of values ranging from 0 to 1. The\n  default mode is :image. In :image, if an image is 100 x 200 pixels,\n  mapping the image onto the entire size of a quad would require the\n  points (0,0) (0,100) (100,200) (0,200). The same mapping in\n  NORMAL_SPACE is (0,0) (0,1) (1,1) (0,1).",
   :what :fn},
  redraw
- {:args ({:value [], :type :both}),
+ {:args ({:value [n], :type :cljs} {:value [], :type :both}),
   :category "Structure",
   :added "1.0",
   :name redraw,
@@ -3025,7 +3040,7 @@
   :requires-bindings true,
   :link "http://www.processing.org/reference/redraw_.html",
   :docstring
-  "Executes the code within the draw fn one time. This functions\n  allows the program to update the display window only when necessary,\n  for example when an event registered by mouse-pressed or\n  key-pressed occurs.\n\n  In structuring a program, it only makes sense to call redraw\n  within events such as mouse-pressed. This is because redraw does\n  not run draw immediately (it only sets a flag that indicates an\n  update is needed).\n\n  Calling redraw within draw has no effect because draw is\n  continuously called anyway.",
+  "Executes the code within the draw fn one time (or n times in cljs). This function\n  allows the program to update the display window only when necessary,\n  for example when an event registered by mouse-pressed or\n  key-pressed occurs.\n\n  In structuring a program, it only makes sense to call redraw\n  within events such as mouse-pressed. This is because redraw does\n  not run draw immediately (it only sets a flag that indicates an\n  update is needed).\n\n  Calling redraw within draw has no effect because draw is\n  continuously called anyway.",
   :what :fn},
  get-pixel
  {:args
@@ -3059,7 +3074,7 @@
   :requires-bindings true,
   :link "http://www.processing.org/reference/rotate_.html",
   :docstring
-  "Rotates a shape the amount specified by the angle parameter. Angles\n  should be specified in radians (values from 0 to TWO-PI) or\n  converted to radians with the radians function.\n\n  Objects are always rotated around their relative position to the\n  origin and positive numbers rotate objects in a clockwise\n  direction. Transformations apply to everything that happens after\n  and subsequent calls to the function accumulates the effect. For\n  example, calling (rotate HALF-PI) and then (rotate HALF-PI) is the\n  same as (rotate PI). All tranformations are reset when draw begins\n  again.\n\n  Technically, rotate multiplies the current transformation matrix by\n  a rotation matrix. This function can be further controlled by the\n  push-matrix and pop-matrix.\n\n  When 4 arguments provides it produces a rotation of angle degrees\n  around the vector x y z. Check examples for to better understand.\n  This rotation follows the right-hand rule, so if the vector x y z points\n  toward the user, the rotation will be counterclockwise.",
+  "Rotates a shape the amount specified by the angle parameter. Angles\n  should be specified in radians (values from 0 to TWO-PI) or\n  converted to radians with the radians function.\n\n  Objects are always rotated around their relative position to the\n  origin and positive numbers rotate objects in a clockwise\n  direction. Transformations apply to everything that happens after\n  and subsequent calls to the function accumulates the effect. For\n  example, calling (rotate HALF-PI) and then (rotate HALF-PI) is the\n  same as (rotate PI). All transformations are reset when draw begins\n  again.\n\n  Technically, rotate multiplies the current transformation matrix by\n  a rotation matrix. This function can be further controlled by the\n  push-matrix and pop-matrix.\n\n  When 4 arguments provides it produces a rotation of angle degrees\n  around the vector x y z. Check examples for to better understand.\n  This rotation follows the right-hand rule, so if the vector x y z points\n  toward the user, the rotation will be counterclockwise.",
   :what :fn},
  set-pixel
  {:args
@@ -3086,7 +3101,7 @@
   :requires-bindings true,
   :link "http://www.processing.org/reference/pushMatrix_.html",
   :docstring
-  "Pushes the current transformation matrix onto the matrix\n  stack. Understanding push-matrix and pop-matrix requires\n  understanding the concept of a matrix stack. The push-matrix\n  function saves the current coordinate system to the stack and\n  pop-matrix restores the prior coordinate system. push-matrix and\n  pop-matrix are used in conjuction with the other transformation\n  methods and may be embedded to control the scope of the\n  transformations.",
+  "Pushes the current transformation matrix onto the matrix\n  stack. Understanding push-matrix and pop-matrix requires\n  understanding the concept of a matrix stack. The push-matrix\n  function saves the current coordinate system to the stack and\n  pop-matrix restores the prior coordinate system. push-matrix and\n  pop-matrix are used in conjunction with the other transformation\n  methods and may be embedded to control the scope of the\n  transformations.",
   :what :fn},
  no-smooth
  {:args ({:value [], :type :both}),
@@ -3127,7 +3142,7 @@
   :requires-bindings true,
   :link "http://www.processing.org/reference/camera_.html",
   :docstring
-  "Sets the position of the camera through setting the eye position,\n  the center of the scene, and which axis is facing upward. Moving the\n  eye position and the direction it is pointing (the center of the\n  scene) allows the images to be seen from different angles. The\n  version without any parameters sets the camera to the default\n  position, pointing to the center of the display window with the Y\n  axis as up. The default values are:\n\n  eyeX:     (/ (width) 2.0)\n  eyeY:     (/ (height) 2.0)\n  eyeZ:     (/ (/ (height) 2.0) (tan (/ (* Math/PI 60.0) 360.0)))\n  centerX:  (/ (width) 2.0)\n  centerY:  (/ (height) 2.0)\n  centerZ:  0\n  upX:      0\n  upY:      1\n  upZ:      0\n\n  Similar imilar to gluLookAt() in OpenGL, but it first clears the\n  current camera settings.",
+  "Sets the position of the camera through setting the eye position,\n  the center of the scene, and which axis is facing upward. Moving the\n  eye position and the direction it is pointing (the center of the\n  scene) allows the images to be seen from different angles. The\n  version without any parameters sets the camera to the default\n  position, pointing to the center of the display window with the Y\n  axis as up. The default values are:\n\n  eyeX:     (/ (width) 2.0)\n  eyeY:     (/ (height) 2.0)\n  eyeZ:     (/ (/ (height) 2.0) (tan (/ (* Math/PI 60.0) 360.0)))\n  centerX:  (/ (width) 2.0)\n  centerY:  (/ (height) 2.0)\n  centerZ:  0\n  upX:      0\n  upY:      1\n  upZ:      0\n\n  Similar to gluLookAt() in OpenGL, but it first clears the\n  current camera settings.",
   :what :fn},
  translate
  {:args
@@ -3222,7 +3237,7 @@
   :requires-bindings true,
   :link "http://www.processing.org/reference/image_.html",
   :docstring
-  "Displays images to the screen. Processing currently works with GIF,\n  JPEG, and Targa images. The color of an image may be modified with\n  the tint function and if a GIF has transparency, it will maintain\n  its transparency. The img parameter specifies the image to display\n  and the x and y parameters define the location of the image from its\n  upper-left corner. The image is displayed at its original size\n  unless the width and height parameters specify a different size. The\n  image-mode fn changes the way the parameters work. A call to\n  (image-mode :corners) will change the width and height parameters to\n  define the x and y values of the opposite corner of the image.\n\n  Starting with release 0124, when using the default (JAVA2D)\n  renderer, smooth will also improve image quality of resized\n  images.",
+  "Displays images to the screen. Processing currently works with GIF,\n  JPEG, and Targa images. The color of an image may be modified with\n  the tint function and if a GIF has transparency, it will maintain\n  its transparency. The img parameter specifies the image to display\n  and the x and y parameters define the location of the image from its\n  upper-left corner. The image is displayed at its original size\n  unless the width and height parameters specify a different size. The\n  image-mode fn changes the way the parameters work. A call to\n  (image-mode :corners) will change the width and height parameters to\n   define the x and y values of the opposite corner of the image.",
   :what :fn},
  unbinary
  {:args ({:value [str-val], :type :both}),
@@ -3251,12 +3266,12 @@
   "Removes the current fill value for displaying images and reverts to\n  displaying images with their original hues.",
   :what :fn},
  no-lights
- {:args ({:value [], :type :both}),
+ {:args #{[]},
   :category "Lights, Camera",
   :added "1.0",
   :name no-lights,
   :subcategory "Lights",
-  :type :both,
+  :type :clj,
   :processing-name "noLights()",
   :requires-bindings true,
   :link "http://www.processing.org/reference/noLights_.html",

--- a/snippets-data-3.0.0.clj
+++ b/snippets-data-3.0.0.clj
@@ -3,7 +3,7 @@
   :name "use-hex-colors",
   :opts {:settings nil},
   :draw
-  "((q/lerp-color 4278255360 4278190335 0.5) (q/hue 4279312947) (q/saturation 4279312947) (q/brightness 4279312947) (q/red 4279312947) (q/green 4279312947) (q/blue 4279312947) (q/blend-color 4278255360 4294901760 :blend) (q/background 4279312947))",
+  "((q/hue \"0xFF112233\") (q/saturation \"0xFF112233\") (q/brightness \"0xFF112233\") (q/red \"0xFF112233\") (q/green \"0xFF112233\") (q/blue \"0xFF112233\") (q/background \"0xFF112233\"))",
   :setup "()",
   :target :cljs}
  {:fns ["lerp-color"],
@@ -11,7 +11,23 @@
   :name "lerp-color",
   :opts {:settings nil},
   :draw
-  "((q/background 255) (let [c1 (q/color 255 0 0) c2 (q/color 0 0 255)] (comment \"draw colors that transition from c1 to c2\") (dotimes [i 6] (q/fill (q/lerp-color c1 c2 (/ i 5))) (q/rect (* i 70) (* i 70) 100 100))))",
+  "((q/background 255) (let [red (q/color 255 0 0) blue (q/color 0 0 255)] (comment \"draw colors that transition from red to blue\") (dotimes [i 6] (q/fill (q/lerp-color red blue (/ i 5))) (q/rect (* i 70) (* i 70) 100 100))))",
+  :setup "()",
+  :target :cljs}
+ {:fns ["current-stroke"],
+  :ns "quil.snippets.color.creating-and-reading",
+  :name "current-stroke",
+  :opts {:settings nil},
+  :draw
+  "((q/background 255) (comment \"set to red\") (q/stroke 255 0 0) (q/rect 0 0 100 100) (let [_ (comment \"remember current color\") cur-stroke (q/current-stroke)] (comment \"change to blue\") (q/stroke 0 0 255) (q/rect 70 70 100 100) (comment \"change back to the original color\") (q/stroke cur-stroke) (q/rect 140 140 100 100)))",
+  :setup "()",
+  :target :cljs}
+ {:fns ["current-fill"],
+  :ns "quil.snippets.color.creating-and-reading",
+  :name "current-fill",
+  :opts {:settings nil},
+  :draw
+  "((q/background 255) (comment \"set to red\") (q/fill 255 0 0) (q/rect 0 0 100 100) (let [_ (comment \"remember current color\") cur-fill (q/current-fill)] (comment \"change to blue\") (q/fill 0 0 255) (q/rect 70 70 100 100) (comment \"change back to the original color\") (q/fill cur-fill) (q/rect 140 140 100 100)))",
   :setup "()",
   :target :cljs}
  {:fns ["color-mode"],
@@ -24,10 +40,10 @@
   :target :cljs}
  {:fns ["color-mode"],
   :ns "quil.snippets.color.creating-and-reading",
-  :name "color-mode-hsb",
+  :name "color-mode-hsl",
   :opts {:settings nil},
   :draw
-  "((q/color-mode :rgb 255) (q/background 255) (q/color-mode :hsb) (q/fill 255 255 255) (q/rect 0 0 100 100))",
+  "((q/color-mode :rgb 255) (q/background 255) (q/color-mode :hsl) (comment \"use red color\") (q/fill 255 255 127) (q/rect 0 0 100 100))",
   :setup "()",
   :target :cljs}
  {:fns ["color"],
@@ -43,7 +59,7 @@
   :name "brightness",
   :opts {:settings nil},
   :draw
-  "((q/background 255) (q/color-mode :hsb) (let [col (q/color 100 230 100)] (q/fill col) (q/rect 0 0 100 100) (q/fill 255 255 (q/brightness col)) (q/rect 70 70 100 100)))",
+  "((q/background 255) (q/color-mode :hsb) (let [dark-green (q/color 100 230 100)] (q/fill dark-green) (q/rect 0 0 100 100) (comment \"use the same brightness but different color\") (q/fill 255 255 (q/brightness dark-green)) (q/rect 70 70 100 100)))",
   :setup "()",
   :target :cljs}
  {:fns ["saturation"],
@@ -51,7 +67,7 @@
   :name "saturation",
   :opts {:settings nil},
   :draw
-  "((q/background 255) (q/color-mode :hsb) (let [col (q/color 100 230 100)] (q/fill col) (q/rect 0 0 100 100) (q/fill 255 (q/saturation col) 255) (q/rect 70 70 100 100)))",
+  "((q/background 255) (q/color-mode :hsb) (let [dark-green (q/color 100 230 100)] (q/fill dark-green) (q/rect 0 0 100 100) (comment \"use the same saturation but different color\") (q/fill 255 (q/saturation dark-green) 255) (q/rect 70 70 100 100)))",
   :setup "()",
   :target :cljs}
  {:fns ["hue"],
@@ -59,7 +75,7 @@
   :name "hue",
   :opts {:settings nil},
   :draw
-  "((q/background 255) (q/color-mode :hsb) (let [col (q/color 100 230 100)] (q/fill col) (q/rect 0 0 100 100) (q/fill (q/hue col) 255 255) (q/rect 70 70 100 100)))",
+  "((q/background 255) (q/color-mode :hsb) (let [dark-green (q/color 100 230 100)] (q/fill dark-green) (q/rect 0 0 100 100) (comment \"use the hue (green) but make it bright\") (q/fill (q/hue dark-green) 255 255) (q/rect 70 70 100 100)))",
   :setup "()",
   :target :cljs}
  {:fns ["blue"],
@@ -67,7 +83,7 @@
   :name "blue",
   :opts {:settings nil},
   :draw
-  "((q/background 255) (let [col (q/color 123 50 220)] (q/fill col) (q/rect 0 0 100 100) (q/fill 0 0 (q/blue col)) (q/rect 70 70 100 100)))",
+  "((q/background 255) (let [purple (q/color 123 50 220)] (q/fill purple) (q/rect 0 0 100 100) (comment \"use only blue component of purple\") (q/fill 0 0 (q/blue purple)) (q/rect 70 70 100 100)))",
   :setup "()",
   :target :cljs}
  {:fns ["green"],
@@ -75,7 +91,7 @@
   :name "green",
   :opts {:settings nil},
   :draw
-  "((q/background 255) (let [col (q/color 123 50 220)] (q/fill col) (q/rect 0 0 100 100) (q/fill 0 (q/green col) 0) (q/rect 70 70 100 100)))",
+  "((q/background 255) (let [purple (q/color 123 50 220)] (q/fill purple) (q/rect 0 0 100 100) (comment \"use only green component of purple\") (q/fill 0 (q/green purple) 0) (q/rect 70 70 100 100)))",
   :setup "()",
   :target :cljs}
  {:fns ["red"],
@@ -83,15 +99,15 @@
   :name "red",
   :opts {:settings nil},
   :draw
-  "((q/background 255) (let [col (q/color 123 50 220)] (q/fill col) (q/rect 0 0 100 100) (q/fill (q/red col) 0 0) (q/rect 70 70 100 100)))",
+  "((q/background 255) (let [purple (q/color 123 50 220)] (q/fill purple) (q/rect 0 0 100 100) (comment \"use only red component of purple\") (q/fill (q/red purple) 0 0) (q/rect 70 70 100 100)))",
   :setup "()",
   :target :cljs}
- {:fns ["blend-color"],
+ {:fns ["lightness"],
   :ns "quil.snippets.color.creating-and-reading",
-  :name "blend-color",
+  :name "lightness",
   :opts {:settings nil},
   :draw
-  "((q/background 255) (let [_ (comment \"very transparent red\") c1 (q/color 255 100 20 50) _ (comment \"not very transparent blue\") c2 (q/color 40 200 255 200) modes [:blend :add :subtract :darkest :lightest :difference :exclusion :multiply :screen :overlay :hard-light :soft-light :dodge :burn] splitted (partition-all 3 modes)] (comment \"draw 2 rectangles with colors c1 and c2\") (q/fill c1) (q/rect 0 0 70 70) (q/fill c2) (q/rect 100 0 70 70) (comment \"draw all possible blended colors\") (dotimes [row (count splitted)] (dotimes [col (count (nth splitted row))] (let [mode (nth (nth splitted row) col)] (q/fill (q/blend-color c1 c2 mode))) (q/rect (* col 100) (* (inc row) 100) 70 70)))))",
+  "((q/background 255) (q/color-mode :hsl) (let [_ (comment \"blue with low lightness (70 of 255)\") blue (q/color 156 255 70) _ (comment \"extract lightness\") l (q/lightness blue) _ (comment \"create red with same lightness\") red (q/color 0 255 l)] (q/fill blue) (q/rect 0 0 100 100) (q/fill red) (q/rect 70 70 100 100)))",
   :setup "()",
   :target :cljs}
  {:fns ["alpha"],
@@ -110,20 +126,20 @@
   "((q/fill 0) (let [txt \"Hello, world!\" width (q/text-width txt)] (q/text txt 20 20) (q/text (str \"Width of text above is \" width) 20 40)))",
   :setup "()",
   :target :cljs}
+ {:fns ["text-style"],
+  :ns "quil.snippets.typography.attributes",
+  :name "text-style",
+  :opts {:settings nil},
+  :draw
+  "((q/fill 0) (q/text-style :normal) (q/text \"text-style: normal\" 20 50) (q/text-style :italic) (q/text \"text-style: italic\" 20 100) (q/text-style :bold) (q/text \"text-style: bold\" 20 150))",
+  :setup "()",
+  :target :cljs}
  {:fns ["text-size"],
   :ns "quil.snippets.typography.attributes",
   :name "text-size",
   :opts {:settings nil},
   :draw
   "((q/fill 0) (doseq [ind (range 6) :let [size (+ 10 (* ind 5))]] (q/text-size size) (q/text (str \"Text size: \" size) 20 (+ 20 (* ind 80)))))",
-  :setup "()",
-  :target :cljs}
- {:fns ["text-mode"],
-  :ns "quil.snippets.typography.attributes",
-  :name "text-mode",
-  :opts {:renderer :p2d, :settings nil},
-  :draw
-  "((q/fill 0) (q/text-mode :model) (q/text \"text-mode: model\" 20 50) (q/text-mode :shape) (q/text \"text-mode: shape\" 20 100))",
   :setup "()",
   :target :cljs}
  {:fns ["text-leading"],
@@ -139,15 +155,15 @@
   :name "text-align",
   :opts {:settings nil},
   :draw
-  "((q/fill 0) (q/stroke 255 0 0) (q/stroke-weight 5) (let [h-align [:left :center :right] v-align [:top :bottom :center :baseline]] (comment \"text-align with single argument\") (doseq [ind (range (count h-align)) :let [x 50 y (+ 20 (* ind 50))]] (q/text-align (h-align ind)) (q/text (name (h-align ind)) x y) (q/point x y)) (comment \"text-align with multiple arguments\") (doseq [ind-h (range (count h-align)) ind-v (range (count v-align)) :let [x (+ 70 (* ind-v 100)) y (+ 250 (* ind-h 50)) h-al (h-align ind-h) v-al (v-align ind-v) txt (str (name h-al) \"+\" (name v-al))]] (q/text-align h-al v-al) (q/text txt x y) (q/point x y))))",
+  "((q/fill 0) (let [h-align [:left :center :right] v-align [:top :bottom :center :baseline]] (comment \"text-align with single argument\") (doseq [ind (range (count h-align)) :let [x 50 y (+ 20 (* ind 50))]] (q/text-align (h-align ind)) (q/text (name (h-align ind)) x y) (q/push-style) (q/stroke 255 0 0) (q/stroke-weight 5) (q/point x y) (q/pop-style)) (comment \"text-align with multiple arguments\") (doseq [ind-h (range (count h-align)) ind-v (range (count v-align)) :let [x (+ 70 (* ind-v 100)) y (+ 250 (* ind-h 50)) h-al (h-align ind-h) v-al (v-align ind-v) txt (str (name h-al) \"+\" (name v-al))]] (q/text-align h-al v-al) (q/text txt x y) (q/push-style) (q/stroke 255 0 0) (q/stroke-weight 5) (q/point x y) (q/pop-style))))",
   :setup "()",
   :target :cljs}
- {:fns ["set-image"],
+ {:fns ["set-image" "set-pixel"],
   :ns "quil.snippets.image.pixels",
   :name "set-image",
   :opts {:settings nil},
   :draw
-  "((q/background 255) (let [im (q/create-image 100 100 :rgb)] (comment \"draw gradient on the image\") (dotimes [x 100] (dotimes [y 100] (q/set-pixel im x y (q/color (* 2 x) (* 2 y) (+ x y))))) (comment \"draw image on sketch\") (q/set-image 10 10 im)))",
+  "((q/background 255) (let [im (q/create-image 100 100)] (comment \"draw gradient on the image\") (dotimes [x 100] (dotimes [y 100] (q/set-pixel im x y (q/color (* 2 x) (* 2 y) (+ x y))))) (q/update-pixels im) (comment \"draw image on sketch\") (q/set-image 10 10 im)))",
   :setup "()",
   :target :cljs}
  {:fns ["pixels" "update-pixels"],
@@ -155,7 +171,7 @@
   :name "pixels-update-pixels",
   :opts {:renderer :p2d, :settings nil},
   :draw
-  "((q/background 255) (let [size 50 gr (q/create-graphics size size :p2d)] (comment \"draw red circle on the graphics\") (q/with-graphics gr (q/background 255) (q/fill 255 0 0) (q/ellipse (/ size 2) (/ size 2) (* size (/ 2 3)) (* size (/ 2 3)))) (comment \"draw original graphics\") (q/image gr 0 0) (comment \"get pixels of the graphics and copy\") (comment \"the first half of all pixels to the second half\") (let [px (q/pixels gr) half (/ (* size size) 2)] (dotimes [i half] (aset px (+ i half) (aget px i)))) (q/update-pixels gr) (q/image gr (+ size 20) 0) (comment \"get pixels of the sketch itself and copy\") (comment \"the first half of all pixels to the second half\") (let [px (q/pixels) half (/ (* (q/width) (q/height)) 10)] (dotimes [i half] (aset px (+ i half) (aget px i)))) (q/update-pixels)))",
+  "((q/background 255) (let [size 50 gr (q/create-graphics size size :p2d)] (comment \"draw red circle on the graphics\") (q/with-graphics gr (q/background 255) (q/fill 255 0 0) (q/ellipse (/ size 2) (/ size 2) (* size (/ 2 3)) (* size (/ 2 3)))) (comment \"draw original graphics\") (q/image gr 0 0) (comment \"get pixels of the graphics and copy\") (comment \"the first half of all pixels to the second half\") (let [px (q/pixels gr) half (* 4 (* (q/display-density) size) (/ (* (q/display-density) size) 2))] (dotimes [i half] (aset px (+ i half) (aget px i)))) (q/update-pixels gr) (q/image gr (+ size 20) 0) (comment \"get pixels of the sketch itself and copy\") (comment \"the first half of all pixels to the second half\") (let [px (q/pixels) half (/ (* 4 (* (q/display-density) (q/width)) (* (q/display-density) (q/height))) 10)] (dotimes [i half] (aset px (+ i half) (aget px i)))) (q/update-pixels)))",
   :setup "()",
   :target :cljs}
  {:fns ["get-pixel"],
@@ -171,7 +187,7 @@
   :name "display-filter",
   :opts {:settings nil},
   :draw
-  "((q/background 255) (let [orig (q/create-graphics 100 100) modes [[:threshold] [:threshold 0.7] [:gray] [:invert] [:posterize 20] [:blur] [:blur 3] [:opaque] [:erode] [:dilate]] splitted (partition-all 4 modes)] (comment \"draw 10x10 square from circles of different color\") (q/with-graphics orig (q/color-mode :rgb 1.0) (q/background 1) (q/no-stroke) (q/ellipse-mode :corner) (doseq [r (range 0 1 0.1) b (range 0 1 0.1)] (q/fill r 0 b) (q/ellipse (* r 100) (* b 100) 10 10))) (comment \"apply different filters, four filters per row\") (q/image orig 0 0) (dotimes [row (count splitted)] (dotimes [col (count (nth splitted row))] (let [mode (nth (nth splitted row) col) dest (q/create-graphics 100 100)] (q/with-graphics dest (q/image orig 0 0) (apply q/display-filter mode)) (q/image dest (* col 120) (* 120 (inc row))))))))",
+  "((q/background 255) (let [orig (q/create-graphics 100 100) modes [[:threshold] [:threshold 0.2] [:gray] [:invert] [:posterize 20] [:blur] [:blur 3] [:opaque] [:erode] [:dilate]] splitted (partition-all 4 modes)] (comment \"draw 10x10 square from circles of different color\") (q/with-graphics orig (q/color-mode :rgb 1.0) (q/background 1) (q/no-stroke) (q/ellipse-mode :corner) (doseq [r (range 0 1 0.1) b (range 0 1 0.1)] (q/fill r 0 b) (q/ellipse (* r 100) (* b 100) 10 10))) (comment \"apply different filters, four filters per row\") (q/image orig 0 0) (dotimes [row (count splitted)] (dotimes [col (count (nth splitted row))] (let [mode (nth (nth splitted row) col) dest (q/create-graphics 100 100)] (q/with-graphics dest (q/image orig 0 0) (apply q/display-filter mode)) (q/image dest (* col 120) (* 120 (inc row))))))))",
   :setup "()",
   :target :cljs}
  {:fns ["image-filter"],
@@ -179,7 +195,7 @@
   :name "image-filter",
   :opts {:settings nil},
   :draw
-  "((q/background 255) (let [orig (q/create-graphics 100 100) modes [[:threshold] [:threshold 0.7] [:gray] [:invert] [:posterize 20] [:blur] [:blur 3] [:opaque] [:erode] [:dilate]] splitted (partition-all 4 modes)] (comment \"draw 10x10 square from circles of different color\") (q/with-graphics orig (q/color-mode :rgb 1.0) (q/background 1) (q/no-stroke) (q/ellipse-mode :corner) (doseq [r (range 0 1 0.1) b (range 0 1 0.1)] (q/fill r 0 b) (q/ellipse (* r 100) (* b 100) 10 10))) (comment \"apply different filters, four filters per row\") (q/image orig 0 0) (dotimes [row (count splitted)] (dotimes [col (count (nth splitted row))] (let [mode (nth (nth splitted row) col) clone (q/get-pixel orig)] (apply q/image-filter clone mode) (q/image clone (* col 120) (* 120 (inc row))))))))",
+  "((q/background 255) (let [orig (q/create-graphics 100 100) modes [[:threshold] [:threshold 0.2] [:gray] [:invert] [:posterize 20] [:blur] [:blur 3] [:opaque] [:erode] [:dilate]] splitted (partition-all 4 modes)] (comment \"draw 10x10 square from circles of different color\") (q/with-graphics orig (q/color-mode :rgb 1.0) (q/background 1) (q/no-stroke) (q/ellipse-mode :corner) (doseq [r (range 0 1 0.1) b (range 0 1 0.1)] (q/fill r 0 b) (q/ellipse (* r 100) (* b 100) 10 10))) (comment \"apply different filters, four filters per row\") (q/image orig 0 0) (dotimes [row (count splitted)] (dotimes [col (count (nth splitted row))] (let [mode (nth (nth splitted row) col) clone (q/get-pixel orig)] (apply q/image-filter clone mode) (q/image clone (* col 120) (* 120 (inc row))))))))",
   :setup "()",
   :target :cljs}
  {:fns ["copy"],
@@ -187,7 +203,7 @@
   :name "copy",
   :opts {:settings nil},
   :draw
-  "((q/background 255) (let [im (q/create-image 100 100 :rgb)] (comment \" gradient on the image\") (dotimes [x 100] (dotimes [y 100] (q/set-pixel im x y (q/color (* 2 x) (* 2 y) (+ x y))))) (comment \"draw original image\") (q/image im 0 0) (comment \"copy left top quarter to the right top quarter\") (q/copy im im [0 0 50 50] [50 0 50 50]) (comment \"copy the whole image to the sketch, essentially just draw it\") (q/copy im [0 0 100 100] [120 0 100 100]) (comment \"copy top left 50x50 square of sketch \") (comment \"to the 100x100 square at [240, 0] position\") (q/copy [0 0 50 50] [240 0 100 100])))",
+  "((q/background 255) (let [im (q/create-image 100 100)] (comment \" gradient on the image\") (dotimes [x 100] (dotimes [y 100] (q/set-pixel im x y (q/color (* 2 x) (* 2 y) (+ x y))))) (q/update-pixels im) (comment \"draw original image\") (q/image im 0 0) (comment \"copy left top quarter to the right top quarter\") (q/copy im im [0 0 50 50] [50 0 50 50]) (comment \"copy the whole image to the sketch, essentially just draw it\") (q/copy im [0 0 100 100] [120 0 100 100]) (comment \"copy top left 50x50 square of sketch \") (comment \"to the 100x100 square at [240, 0] position\") (q/copy [0 0 50 50] [240 0 100 100])))",
   :setup "()",
   :target :cljs}
  {:fns ["blend"],
@@ -195,8 +211,8 @@
   :name "blend",
   :opts {:settings nil},
   :draw
-  "((q/background 255 100 20 50) (let [gr (q/create-graphics 50 50) modes [:blend :add :subtract :darkest :lightest :difference :exclusion :multiply :screen :overlay :hard-light :soft-light :dodge :burn] splitted (partition-all 5 modes)] (comment \"draw 3 circles of different color on the graphics\") (q/with-graphics gr (q/background 40 200 255 200) (q/fill 255 0 0) (q/ellipse 12 12 20 20) (q/fill 0 255 0) (q/ellipse 38 12 20 20) (q/fill 0 0 255) (q/ellipse 25 38 20 20)) (comment \"all possible blended modes\") (dotimes [row (count splitted)] (dotimes [col (count (nth splitted row))] (let [mode (nth (nth splitted row) col)] (comment \"blend with sketch itself\") (q/blend 400 0 50 50 (* col 55) (* row 55) 50 50 mode) (comment \"blend with graphics\") (q/blend gr 0 0 50 50 (* col 55) (+ 170 (* row 55)) 50 50 mode) (comment \"blend graphics to graphics\") (q/blend gr (q/current-graphics) 0 0 50 50 (* col 55) (+ 340 (* row 55)) 50 50 mode))))))",
-  :setup "()",
+  "((q/background 255 100 20 50) (let [im (q/create-image 50 50) modes [:replace :blend :add :darkest :lightest :difference :exclusion :multiply :screen :overlay :hard-light :soft-light :dodge :burn] splitted (partition-all 5 modes)] (comment \"draw 3 squares of different color on the graphics\") (dotimes [x 10] (dotimes [y 10] (q/set-pixel im (+ x 10) (+ y 10) (q/color 255 0 0)) (q/set-pixel im (+ x 30) (+ y 10) (q/color 0 255 0)) (q/set-pixel im (+ x 20) (+ y 30) (q/color 0 0 255)))) (q/update-pixels im) (comment \"draw all possible blended modes\") (dotimes [row (count splitted)] (dotimes [col (count (nth splitted row))] (let [mode (nth (nth splitted row) col)] (comment \"blend with sketch itself\") (q/blend 400 0 50 50 (* col 55) (* row 55) 50 50 mode) (comment \"blend with image\") (q/blend im 0 0 50 50 (* col 55) (+ 170 (* row 55)) 50 50 mode) (comment \"blend image to image\") (q/blend im (q/current-graphics) 0 0 50 50 (* col 55) (+ 340 (* row 55)) 50 50 mode))))))",
+  :setup "(q/no-loop)",
   :target :cljs}
  {:fns ["millis" "seconds" "minute" "hour" "day" "month" "year"],
   :ns "quil.snippets.input",
@@ -282,7 +298,7 @@
   :name "mag",
   :opts {:settings nil},
   :draw
-  "((q/background 255) (q/fill 0) (q/text (str \"(q/mag 3 4) = \" (q/mag 3 4)) 10 20) (q/text (str \"(q/mag 3 4 5) = \" (q/mag 3 4 5)) 10 40))",
+  "((q/background 255) (q/fill 0) (q/text (str \"(q/mag 3 4) = \" (q/mag 3 4)) 10 20))",
   :setup "()",
   :target :cljs}
  {:fns ["log"],
@@ -354,7 +370,7 @@
   :name "unhex",
   :opts {:settings nil},
   :draw
-  "((q/background 255) (q/fill 0) (q/text (str (q/unhex \"2A\")) 10 10))",
+  "((q/background 255) (q/fill 0) (q/text (str \"(q/unhex \\\"2A\\\") = \" (q/unhex \"2A\")) 10 10))",
   :setup "()",
   :target :cljs}
  {:fns ["unbinary"],
@@ -362,7 +378,7 @@
   :name "unbinary",
   :opts {:settings nil},
   :draw
-  "((q/background 255) (q/fill 0) (q/text (str (q/unbinary \"0101010\")) 10 10))",
+  "((q/background 255) (q/fill 0) (q/text (str \"(q/unbinary \\\"0101010\\\") = \" (q/unbinary \"0101010\")) 10 10))",
   :setup "()",
   :target :cljs}
  {:fns ["hex"],
@@ -370,7 +386,7 @@
   :name "hex",
   :opts {:settings nil},
   :draw
-  "((q/background 255) (q/fill 0) (q/text (q/hex 42) 10 10) (q/text (q/hex 42 5) 10 30))",
+  "((q/background 255) (q/fill 0) (q/text (str \"(q/hex 42) = \" (q/hex 42)) 10 10) (q/text (str \"(q/hex 42 5) = \" (q/hex 42 5)) 10 30))",
   :setup "()",
   :target :cljs}
  {:fns ["binary"],
@@ -378,7 +394,7 @@
   :name "binary",
   :opts {:settings nil},
   :draw
-  "((q/background 255) (q/fill 0) (q/text (q/binary 42) 10 10) (q/text (q/binary 42 5) 10 30))",
+  "((q/background 255) (q/fill 0) (q/text (str \"(q/binary 42) = \" (q/binary 42)) 10 10) (q/text (str \"(q/binary 42 5) = \" (q/binary 42 5)) 10 30))",
   :setup "()",
   :target :cljs}
  {:fns ["tint"],
@@ -389,15 +405,6 @@
   "((q/background 127) (let [gr (q/create-graphics 100 100)] (comment \"draw 4 circles of different color on the graphics\") (q/with-graphics gr (q/background 0 0) (q/fill 255) (q/ellipse 25 25 40 40) (q/fill 255 0 0) (q/ellipse 75 25 40 40) (q/fill 0 255 0) (q/ellipse 25 75 40 40) (q/fill 0 0 255) (q/ellipse 75 75 40 40)) (comment \"apply different types of tint\") (q/no-tint) (q/image gr 0 0) (q/tint 127) (q/image gr 120 0) (q/tint 255 127) (q/image gr 240 0) (q/tint 200 127 180) (q/image gr 0 120) (q/tint 200 127 180 127) (q/image gr 120 120)))",
   :setup "()",
   :target :cljs}
- {:fns ["request-image"],
-  :ns "quil.snippets.image.loading-and-displaying",
-  :name "request-image",
-  :opts {:settings nil},
-  :draw
-  "((if (zero? (.-width (q/state :image))) (q/text \"Loading\" 10 10) (q/image (q/state :image) 0 0)))",
-  :setup
-  "(q/set-state! :image (q/request-image \"https://dummyimage.com/100x100/2c3e50/ffffff.png\"))",
-  :target :cljs}
  {:fns ["no-tint"],
   :ns "quil.snippets.image.loading-and-displaying",
   :name "no-tint",
@@ -406,14 +413,22 @@
   "((q/background 255) (comment \"create graphics with white circle\") (let [gr (q/create-graphics 100 100)] (q/with-graphics gr (q/background 0 0) (q/fill 255) (q/ellipse 50 50 70 70)) (comment \"apply cyan tint\") (q/image gr 0 0) (q/tint 127 255 255) (q/image gr 100 0) (comment \"remove tint\") (q/no-tint) (q/image gr 200 0)))",
   :setup "()",
   :target :cljs}
+ {:fns ["mask-image"],
+  :ns "quil.snippets.image.loading-and-displaying",
+  :name "mask-image",
+  :opts {:settings nil},
+  :draw
+  "((q/background 255) (comment \"define 2 images and a mask to apply to them\") (let [im (q/create-image 100 100) im2 (q/create-image 100 100) mask (q/create-image 100 100)] (comment \"first image is a blue square with a red cross\") (dotimes [x 100] (dotimes [y 100] (if (or (< 0 (- x y) 5) (< 95 (+ x y) 100)) (q/set-pixel im x y (q/color 255 0 0 255)) (q/set-pixel im x y (q/color 0 0 255))))) (q/update-pixels im) (comment \"second image is a green cross\") (dotimes [x 100] (dotimes [y 5] (q/set-pixel im2 (+ y 47) x (q/color 0 255 0)) (q/set-pixel im2 x (+ y 47) (q/color 0 255 0)))) (q/update-pixels im2) (comment \"mask is rectangles with different shades of gray\") (dotimes [x 100] (dotimes [y 100] (q/set-pixel mask x y (q/color 0 (* 40 (+ (quot x 20) (quot y 20))))))) (q/update-pixels mask) (comment \"draw first image, mask and image with mask applied\") (q/image im 20 20) (q/image mask 140 20) (q/mask-image im mask) (q/image im 260 20) (comment \"draw second image, mask and image with mask applied\") (q/image im2 20 140) (q/image mask 140 140) (q/mask-image im2 mask) (q/image im2 260 140)))",
+  :setup "()",
+  :target :cljs}
  {:fns ["load-image"],
   :ns "quil.snippets.image.loading-and-displaying",
   :name "load-image",
   :opts {:settings nil},
   :draw
-  "((let [im (q/state :image)] (comment \"image is loaded once its width is non-zero\") (when-not (zero? (.-width im)) (q/image im 0 0))))",
+  "((let [im (q/state :image)] (comment \"check if image is loaded using function loaded?\") (when (q/loaded? im) (q/image im 0 0))))",
   :setup
-  "(let [_ (comment \"create url to load image 100x100\") url (str \"https://dummyimage.com/100x100/2c3e50/ffffff.png\")] (q/set-state! :image (q/load-image url)))",
+  "(let [_ (comment \"create url to load image 100x100\") url \"https://placekitten.com/100/100\"] (q/set-state! :image (q/load-image url)))",
   :target :cljs}
  {:fns ["image-mode"],
   :ns "quil.snippets.image.loading-and-displaying",
@@ -431,29 +446,13 @@
   "((q/background 255) (comment \"create graphics with circle\") (let [gr (q/create-graphics 70 70)] (q/with-graphics gr (q/ellipse 35 35 70 70)) (comment \"draw graphics twice\") (q/image gr 0 0) (q/image gr 100 0 100 70)))",
   :setup "()",
   :target :cljs}
- {:fns ["shape-mode"],
-  :ns "quil.snippets.shape.loading-and-displaying",
-  :name "shape-mode",
-  :opts {:renderer :p2d, :settings nil},
-  :draw
-  "((let [sh (q/load-shape \"Heckert_GNU_white.svg\")] (q/stroke-weight 5) (q/stroke 255 0 0) (q/shape-mode :corner) (q/shape sh 20 20 200 200) (q/point 20 20) (q/shape-mode :corners) (q/shape sh 270 20 370 120) (q/point 270 20) (q/point 370 120) (q/shape-mode :center) (q/shape sh 100 350 150 150) (q/point 100 350)))",
-  :setup "()",
-  :target :cljs}
- {:fns ["shape"],
+ {:fns ["shape" "load-shape"],
   :ns "quil.snippets.shape.loading-and-displaying",
   :name "shape",
-  :opts {:renderer :p2d, :settings nil},
-  :draw
-  "((let [sh (q/load-shape \"Heckert_GNU_white.svg\")] (q/shape sh) (q/shape sh 100 100) (q/shape sh 300 300 200 200)))",
-  :setup "()",
-  :target :cljs}
- {:fns ["load-shape"],
-  :ns "quil.snippets.shape.loading-and-displaying",
-  :name "load-shape",
-  :opts {:renderer :p2d, :settings nil},
-  :draw
-  "((let [sh (q/load-shape \"Heckert_GNU_white.svg\")] (q/shape sh 0 0 500 500)))",
-  :setup "()",
+  :opts {:renderer :p3d, :settings nil},
+  :draw "((let [sh (q/state :shp)] (q/shape sh)))",
+  :setup
+  "(let [sh (q/load-shape \"octahedron.obj\")] (q/set-state! :shp sh))",
   :target :cljs}
  {:fns ["text-descent"],
   :ns "quil.snippets.typography.metrics",
@@ -476,7 +475,7 @@
   :name "translate",
   :opts {:renderer :p3d, :settings nil},
   :draw
-  "((q/camera 200 200 200 0 0 0 0 0 -1) (q/no-fill) (q/box 50) (q/translate 100 0) (q/box 50) (q/translate [-100 100]) (q/box 50) (q/translate 0 -100 100) (q/box 50))",
+  "((comment \"setup camera and draw box at [0 0 0]\") (q/camera 200 200 200 0 0 0 0 0 -1) (q/no-fill) (q/box 50) (comment \"draw 3 identical boxes in 3 different positions\") (comment \"using different translate calls\") (q/translate 100 0) (q/box 50) (q/translate [-100 100]) (q/box 50) (q/translate 0 -100 100) (q/box 50))",
   :setup "()",
   :target :cljs}
  {:fns ["shear-x" "shear-y"],
@@ -484,7 +483,7 @@
   :name "shear-x-y",
   :opts {:settings nil},
   :draw
-  "((q/with-translation [125 125] (q/rect 0 0 100 50)) (q/with-translation [375 125] (q/shear-y 0.5) (q/rect 0 0 100 50)) (q/with-translation [125 375] (q/shear-x 0.5) (q/rect 0 0 100 50)))",
+  "((comment \"draw normal rect\") (q/with-translation [125 125] (q/rect 0 0 100 50)) (comment \"draw rect sheared by y\") (q/with-translation [375 125] (q/shear-y 0.5) (q/rect 0 0 100 50)) (comment \"draw rect sheared by x\") (q/with-translation [125 375] (q/shear-x 0.5) (q/rect 0 0 100 50)))",
   :setup "()",
   :target :cljs}
  {:fns ["scale"],
@@ -492,7 +491,7 @@
   :name "scale",
   :opts {:renderer :p3d, :settings nil},
   :draw
-  "((q/camera 200 200 200 0 0 0 0 0 -1) (q/no-fill) (q/box 50) (q/with-translation [100 0 0] (q/scale 0.5) (q/box 50) (q/scale 2)) (q/with-translation [0 100 0] (q/scale 1 0.5) (q/box 50) (q/scale 1 2)) (q/with-translation [0 0 100] (q/scale 0.5 1 1.5) (q/box 50) (q/scale 2 1 0.75)))",
+  "((comment \"setup camera and draw box at [0 0 0]\") (q/camera 200 200 200 0 0 0 0 0 -1) (q/no-fill) (q/box 50) (comment \"draw box 50% smaller\") (q/with-translation [100 0 0] (q/scale 0.5) (q/box 50) (q/scale 2)) (comment \"draw box 50% narrower but same length/height\") (q/with-translation [0 100 0] (q/scale 1 0.5) (q/box 50) (q/scale 1 2)) (comment \"draw box 50% shorter and 150% taller, but same width\") (q/with-translation [0 0 100] (q/scale 0.5 1 1.5) (q/box 50) (q/scale 2 1 0.75)))",
   :setup "()",
   :target :cljs}
  {:fns ["rotate-x" "rotate-y" "rotate-z"],
@@ -500,15 +499,15 @@
   :name "rotate-x-y-z",
   :opts {:renderer :p3d, :settings nil},
   :draw
-  "((q/camera 200 200 200 0 0 0 0 0 -1) (q/no-fill) (q/box 50) (q/push-matrix) (q/translate 100 0 0) (q/rotate-x 0.5) (q/box 50) (q/pop-matrix) (q/push-matrix) (q/translate 0 100 0) (q/rotate-y 0.5) (q/box 50) (q/pop-matrix) (q/push-matrix) (q/translate 0 0 100) (q/rotate-z 0.5) (q/box 50) (q/pop-matrix))",
+  "((comment \"setup camera and draw box at [0 0 0]\") (q/camera 200 200 200 0 0 0 0 0 -1) (q/no-fill) (q/box 50) (q/push-matrix) (comment \"move, rotate x axis and draw box\") (q/translate 100 0 0) (q/rotate-x 0.5) (q/box 50) (q/pop-matrix) (q/push-matrix) (comment \"move, rotate y axis and draw box\") (q/translate 0 100 0) (q/rotate-y 0.5) (q/box 50) (q/pop-matrix) (q/push-matrix) (comment \"move, rotate z axis and draw box\") (q/translate 0 0 100) (q/rotate-z 0.5) (q/box 50) (q/pop-matrix))",
   :setup "()",
   :target :cljs}
  {:fns ["rotate"],
   :ns "quil.snippets.transform",
   :name "rotate",
-  :opts {:renderer :p3d, :settings nil},
+  :opts {:settings nil},
   :draw
-  "((q/camera 200 200 200 0 0 0 0 0 -1) (q/no-fill) (q/box 50) (q/push-matrix) (q/translate 100 0 0) (q/rotate 0.5) (q/box 50) (q/pop-matrix) (q/push-matrix) (q/translate 0 100 0) (q/rotate 0.5 1 0 0) (q/box 50) (q/pop-matrix) (q/push-matrix) (q/translate 0 0 100) (q/rotate 0.5 0 1 0) (q/box 50) (q/pop-matrix))",
+  "((q/stroke 100) (q/no-fill) (q/rect 0 0 52 52) (q/translate (/ (q/width) 4) (/ (q/height) 4)) (q/rotate (/ q/PI 3)) (q/rect 0 0 52 52))",
   :setup "()",
   :target :cljs}
  {:fns ["reset-matrix"],
@@ -516,15 +515,7 @@
   :name "reset-matrix",
   :opts {:settings nil},
   :draw
-  "((q/rect 0 0 100 50) (q/translate 250 250) (q/rect 0 0 50 50) (q/reset-matrix) (q/rect 0 0 50 100))",
-  :setup "()",
-  :target :cljs}
- {:fns ["print-matrix"],
-  :ns "quil.snippets.transform",
-  :name "print-matrix",
-  :opts {:settings nil},
-  :draw
-  "((q/translate 250 250) (q/rotate 1) (q/rect 0 0 100 100) (q/print-matrix))",
+  "((q/rect 0 0 100 50) (q/translate 250 250) (q/rect 0 0 50 50) (comment \"resetting brings us back to [0, 0]\") (q/reset-matrix) (q/rect 0 0 50 100))",
   :setup "()",
   :target :cljs}
  {:fns ["push-matrix" "pop-matrix"],
@@ -532,16 +523,25 @@
   :name "push-matrix-pop-matrix",
   :opts {:settings nil},
   :draw
-  "((q/fill 255 0 0) (q/translate 20 20) (q/rect 0 0 50 50) (q/translate 150 0) (q/push-matrix) (q/rotate 1) (q/rect 0 0 50 50) (q/pop-matrix) (q/translate 150 0) (q/rect 0 0 50 50))",
+  "((q/fill 255 0 0) (comment \"draw rect at [20, 20]\") (q/translate 20 20) (q/rect 0 0 50 50) (comment \"move by 150 to right and save matrix\") (q/translate 150 0) (q/push-matrix) (comment \"rotate matrix and draw rect\") (q/rotate 1) (q/rect 0 0 50 50) (comment \"pop matrix should revert rotation\") (q/pop-matrix) (comment \"move by another 150 pixels and draw rect\") (q/translate 150 0) (q/rect 0 0 50 50))",
   :setup "()",
   :target :cljs}
  {:fns ["apply-matrix"],
   :ns "quil.snippets.transform",
   :name "apply-matrix",
+  :opts {:settings nil},
+  :draw
+  "((q/no-fill) (q/rect 10 10 50 50) (comment \"move position by 100, 100 and shear\") (q/apply-matrix 1 0 1 1 100 100) (q/rect 10 10 50 50))",
+  :setup "()",
+  :target :cljs}
+ {:fns ["load-shader"],
+  :ns "quil.snippets.rendering",
+  :name "load-shader",
   :opts {:renderer :p3d, :settings nil},
   :draw
-  "((q/camera 200 200 200 0 0 0 0 0 -1) (q/no-fill) (q/box 50) (let [s (q/sin 1) c (q/cos 1)] (q/apply-matrix 1 0 0 0 0 c s 50 0 (- s) c -50 0 0 0 1)) (q/box 50))",
-  :setup "()",
+  "((let [shd (q/state :shader)] (when (q/loaded? shd) (q/shader shd) (q/set-uniform shd \"p\" (array -0.74364388703 0.13182590421)) (q/set-uniform shd \"r\" (* 1.5 (q/exp (* -6.5 (+ 1 (q/sin (/ (q/millis) 2000))))))) (q/quad -1 -1 1 -1 1 1 -1 1))))",
+  :setup
+  "(let [shd (q/load-shader \"shader.frag\" \"shader.vert\")] (q/set-state! :shader shd))",
   :target :cljs}
  {:fns ["with-graphics"],
   :ns "quil.snippets.rendering",
@@ -549,14 +549,6 @@
   :opts {:settings nil},
   :draw
   "((let [gr (q/create-graphics 250 250)] (q/with-graphics gr (q/background 255) (q/fill 255 0 0) (q/triangle 50 30 220 120 20 180)) (q/image gr 0 0) (q/image gr 250 0) (q/image gr 0 250) (q/image gr 250 250)))",
-  :setup "()",
-  :target :cljs}
- {:fns ["hint"],
-  :ns "quil.snippets.rendering",
-  :name "hint",
-  :opts {:renderer :p3d, :settings nil},
-  :draw
-  "((let [hints [:enable-async-saveframe :disable-async-saveframe :enable-depth-test :disable-depth-test :enable-depth-sort :disable-depth-sort :enable-opengl-errors :disable-opengl-errors :enable-depth-mask :disable-depth-mask :enable-optimized-stroke :disable-optimized-stroke :enable-stroke-perspective :disable-stroke-perspective :enable-stroke-pure :disable-stroke-pure :enable-texture-mipmaps :disable-texture-mipmaps]] (doseq [h hints] (q/hint h))) (q/ellipse 250 250 400 200))",
   :setup "()",
   :target :cljs}
  {:fns ["create-graphics"],
@@ -567,12 +559,19 @@
   "((q/background 255) (let [gr (q/create-graphics 100 100)] (q/with-graphics gr (q/background 127) (q/ellipse 50 50 80 40)) (q/image gr 0 0)))",
   :setup "()",
   :target :cljs}
- {:fns ["sphere-detail"],
-  :ns "quil.snippets.shape.primitives-3d",
-  :name "sphere-detail",
-  :opts {:renderer :p3d, :settings nil},
+ {:fns ["blend-mode"],
+  :ns "quil.snippets.image.rendering",
+  :name "blend-mode",
+  :opts {:renderer :p2d, :settings nil},
   :draw
-  "((q/camera 200 200 200 0 0 0 0 0 -1) (q/sphere-detail 30) (q/with-translation [0 0 100] (q/sphere 70)) (q/sphere-detail 15) (q/with-translation [100 0 0] (q/sphere 70)) (q/sphere-detail 30 5) (q/with-translation [0 100 0] (q/sphere 70)))",
+  "((q/background 255) (let [modes [:replace :blend :add :darkest :lightest :difference :exclusion :multiply :screen :overlay :hard-light :soft-light :dodge :burn] splitted (partition-all 4 modes)] (dotimes [row (count splitted)] (dotimes [col (count (nth splitted row))] (let [mode (nth (nth splitted row) col) gr (q/create-graphics 100 100 :p2d)] (q/with-graphics gr (q/background 127) (q/blend-mode mode) (q/no-stroke) (q/fill 255 0 0) (q/rect 10 20 80 20) (q/fill 50 170 255 127) (q/rect 60 10 20 80) (q/fill 200 130 150 200) (q/rect 10 60 80 20) (q/fill 20 240 50 50) (q/rect 20 10 20 80)) (q/image gr (* col 120) (* row 120)))))))",
+  :setup "()",
+  :target :cljs}
+ {:fns ["torus"],
+  :ns "quil.snippets.shape.primitives-3d",
+  :name "torus",
+  :opts {:renderer :p3d, :settings nil},
+  :draw "((q/rotate-x (/ q/PI 4)) (q/torus 70 20))",
   :setup "()",
   :target :cljs}
  {:fns ["sphere"],
@@ -580,6 +579,27 @@
   :name "sphere",
   :opts {:renderer :p3d, :settings nil},
   :draw "((q/camera 200 200 200 0 0 0 0 0 -1) (q/sphere 150))",
+  :setup "()",
+  :target :cljs}
+ {:fns ["ellipsoid"],
+  :ns "quil.snippets.shape.primitives-3d",
+  :name "ellipsoid",
+  :opts {:renderer :p3d, :settings nil},
+  :draw "((q/ellipsoid 40 60 80))",
+  :setup "()",
+  :target :cljs}
+ {:fns ["cylinder"],
+  :ns "quil.snippets.shape.primitives-3d",
+  :name "cylinder",
+  :opts {:renderer :p3d, :settings nil},
+  :draw "((q/rotate-x (* q/PI 1.25)) (q/cylinder 40 140))",
+  :setup "()",
+  :target :cljs}
+ {:fns ["cone"],
+  :ns "quil.snippets.shape.primitives-3d",
+  :name "cone",
+  :opts {:renderer :p3d, :settings nil},
+  :draw "((q/rotate-x (* q/PI 1.25)) (q/cone 80 140))",
   :setup "()",
   :target :cljs}
  {:fns ["box"],
@@ -606,12 +626,12 @@
   "((q/background 255) (q/fill 255 0 0) (q/ellipse 125 125 100 100) (q/push-style) (q/fill 0 0 255) (q/ellipse 250 250 100 100) (q/pop-style) (q/ellipse 375 375 100 100))",
   :setup "()",
   :target :cljs}
- {:fns ["spot-light"],
-  :ns "quil.snippets.lights-camera.lights",
-  :name "spot-light",
+ {:fns ["save"],
+  :ns "quil.snippets.output",
+  :name "save",
   :opts {:renderer :p3d, :settings nil},
   :draw
-  "((q/background 0) (q/camera 100 100 100 0 0 0 0 0 -1) (q/spot-light 255 0 0 50 0 50 -1 0 -1 q/PI 1) (q/spot-light [0 0 255] [0 100 100] [0 -1 -1] q/PI 1) (q/box 50))",
+  "((q/camera 150 150 150 0 0 0 0 0 1) (q/box 100) (q/save \"generated/box.png\"))",
   :setup "()",
   :target :cljs}
  {:fns ["point-light"],
@@ -619,47 +639,7 @@
   :name "point-light",
   :opts {:renderer :p3d, :settings nil},
   :draw
-  "((q/background 0) (q/camera 100 100 100 0 0 0 0 0 -1) (q/point-light 255 150 150 100 100 100) (q/box 50))",
-  :setup "()",
-  :target :cljs}
- {:fns ["normal"],
-  :ns "quil.snippets.lights-camera.lights",
-  :name "normal",
-  :opts {:renderer :p3d, :settings nil},
-  :draw
-  "((q/background 0) (q/camera 100 100 100 40 40 0 0 0 -1) (q/point-light 150 250 150 10 30 50) (q/begin-shape) (q/normal 0 0 1) (doseq [v [[20 20 -10] [80 20 10] [80 80 -10] [20 80 10]]] (apply q/vertex v)) (q/end-shape :close))",
-  :setup "()",
-  :target :cljs}
- {:fns ["no-lights"],
-  :ns "quil.snippets.lights-camera.lights",
-  :name "no-lights",
-  :opts {:renderer :p3d, :settings nil},
-  :draw
-  "((q/background 0) (q/camera 100 100 100 0 0 0 0 0 -1) (q/directional-light 255 150 150 -1 -0.76 -0.5) (q/box 50) (q/no-lights) (q/translate 0 50 0) (q/sphere 20))",
-  :setup "()",
-  :target :cljs}
- {:fns ["lights"],
-  :ns "quil.snippets.lights-camera.lights",
-  :name "lights",
-  :opts {:renderer :p3d, :settings nil},
-  :draw
-  "((q/background 0) (q/camera 100 100 100 0 0 0 0 0 -1) (q/lights) (q/box 50))",
-  :setup "()",
-  :target :cljs}
- {:fns ["light-specular"],
-  :ns "quil.snippets.lights-camera.lights",
-  :name "light-specular",
-  :opts {:renderer :p3d, :settings nil},
-  :draw
-  "((q/background 0) (q/camera 100 100 100 0 0 0 0 0 -1) (q/light-specular 100 100 255) (q/directional-light 255 150 150 -1 -0.76 -0.5) (q/box 50))",
-  :setup "()",
-  :target :cljs}
- {:fns ["light-falloff"],
-  :ns "quil.snippets.lights-camera.lights",
-  :name "light-falloff",
-  :opts {:renderer :p3d, :settings nil},
-  :draw
-  "((q/background 0) (q/camera 100 100 100 0 0 0 0 0 -1) (q/light-falloff 1 0.008 0) (q/point-light 255 150 150 100 100 100) (q/box 50))",
+  "((q/background 0) (q/camera 100 100 100 0 0 0 0 0 -1) (comment \"set light from the same point as camera [100, 100, 100]\") (q/point-light 255 150 150 100 100 100) (q/box 50))",
   :setup "()",
   :target :cljs}
  {:fns ["directional-light"],
@@ -667,7 +647,7 @@
   :name "directional-light",
   :opts {:renderer :p3d, :settings nil},
   :draw
-  "((q/background 0) (q/camera 100 100 100 0 0 0 0 0 -1) (q/directional-light 255 150 150 -1 -0.76 -0.5) (q/box 50))",
+  "((q/background 0) (q/camera 100 100 100 0 0 0 0 0 -1) (comment \"use red-ish color with direction [-1, -0.76, -0.5]\") (q/directional-light 255 150 150 -1 -0.76 -0.5) (q/box 50))",
   :setup "()",
   :target :cljs}
  {:fns ["ambient-light"],
@@ -678,28 +658,36 @@
   "((q/background 0) (q/camera 100 100 100 0 0 0 0 0 1) (q/ambient-light 200 190 230) (q/sphere 50))",
   :setup "()",
   :target :cljs}
- {:fns ["texture-mode"],
+ {:fns ["vertex"],
   :ns "quil.snippets.shape.vertex",
-  :name "texture-mode",
+  :name "vertex",
   :opts {:renderer :p3d, :settings nil},
   :draw
-  "((if (zero? (.-width (q/state :image))) (q/text \"Loading\" 10 10) (let [gr (q/state :image)] (q/with-translation [375 125] (q/begin-shape) (q/texture gr) (q/texture-mode :image) (q/vertex 0 0 0 0) (q/vertex 100 100 100 100) (q/vertex 0 100 0 100) (q/end-shape :close)) (q/with-translation [125 375] (q/begin-shape) (q/texture gr) (q/texture-mode :normal) (q/vertex 0 0 0 0) (q/vertex 100 100 1 1) (q/vertex 0 100 0 1) (q/end-shape :close)))))",
-  :setup "(q/set-state! :image (q/request-image \"texture.jpg\"))",
+  "((q/camera 100 400 200 100 0 0 0 0 -1) (q/line 0 0 0 0 0 150) (q/line 0 0 0 0 150 0) (q/line 0 0 0 150 0 0) (let [txtr (q/create-graphics 100 100)] (q/with-graphics txtr (q/background 255) (comment \"draw belarusian flag, kinda\") (q/fill 255 0 0) (q/rect 0 60 100 40) (q/fill 0 150 0) (q/rect 0 0 100 60)) (comment \"draw blue rect\") (q/fill 0 0 127) (q/begin-shape) (q/vertex 0 0) (q/vertex 100 0) (q/vertex 100 100) (q/vertex 0 100) (q/end-shape :close) (comment \"draw another blue rect\") (q/begin-shape) (q/vertex 0 0 0) (q/vertex 100 0 0) (q/vertex 100 0 100) (q/vertex 0 0 100) (q/end-shape :close) (comment \"draw rect using our custom texture\") (q/begin-shape) (q/texture txtr) (q/vertex 100 0 0 0) (q/vertex 200 0 100 0) (q/vertex 200 100 100 100) (q/vertex 100 100 0 100) (q/end-shape :close) (comment \"draw another rect using our custom texture\") (q/begin-shape) (q/texture txtr) (q/vertex 100 0 0 0 0) (q/vertex 200 0 0 100 0) (q/vertex 200 0 100 100 100) (q/vertex 100 0 100 0 100) (q/end-shape :close)))",
+  :setup "()",
   :target :cljs}
  {:fns ["texture"],
   :ns "quil.snippets.shape.vertex",
   :name "texture",
   :opts {:renderer :p3d, :settings nil},
   :draw
-  "((if (zero? (.-width (q/state :image))) (q/text \"Loading\" 10 10) (let [gr (q/state :image)] (q/with-translation [250 250] (q/begin-shape) (q/texture gr) (q/vertex 50 100 75 100) (q/vertex 100 50 100 75) (q/vertex 100 -50 100 25) (q/vertex 50 -100 75 0) (q/vertex -50 -100 25 0) (q/vertex -100 -50 0 25) (q/vertex -100 50 0 75) (q/vertex -50 100 25 100) (q/end-shape :close)))))",
-  :setup "(q/set-state! :image (q/request-image \"texture.jpg\"))",
+  "((if (zero? (.-width (q/state :image))) (q/text \"Loading\" 10 10) (let [gr (q/state :image)] (q/with-translation [50 0] (q/texture gr) (q/plane 200 200)))))",
+  :setup "(q/set-state! :image (q/load-image \"texture.jpg\"))",
+  :target :cljs}
+ {:fns ["quadratic-vertex"],
+  :ns "quil.snippets.shape.vertex",
+  :name "quadratic-vertex",
+  :opts {:renderer :p3d, :settings nil},
+  :draw
+  "((comment \"setup camera and draw axes\") (q/camera 50 200 50 50 0 0 0 0 -1) (q/line 0 0 0 0 0 100) (q/line 0 0 0 0 100 0) (q/line 0 0 0 100 0 0) (comment \"draw first shape\") (q/begin-shape) (q/vertex 0 0) (q/quadratic-vertex 30 50 10 100) (q/quadratic-vertex 50 -50 90 100) (q/quadratic-vertex 80 50 100 0) (q/end-shape :close) (comment \"draw second shape\") (q/begin-shape) (q/vertex 0 0 0) (q/quadratic-vertex 30 0 50 10 0 100) (q/quadratic-vertex 50 0 -50 90 0 100) (q/quadratic-vertex 80 0 50 100 0 0) (q/end-shape :close))",
+  :setup "()",
   :target :cljs}
  {:fns ["curve-vertex"],
   :ns "quil.snippets.shape.vertex",
   :name "curve-vertex",
   :opts {:renderer :p3d, :settings nil},
   :draw
-  "((q/camera 50 200 50 50 0 0 0 0 1) (q/begin-shape) (q/curve-vertex 0 0) (q/curve-vertex 0 0) (q/curve-vertex 100 20) (q/curve-vertex 100 80) (q/curve-vertex 20 80) (q/curve-vertex 0 0) (q/curve-vertex 0 0) (q/end-shape :close) (q/begin-shape) (q/curve-vertex 0 0 0) (q/curve-vertex 0 0 0) (q/curve-vertex 100 0 20) (q/curve-vertex 100 0 80) (q/curve-vertex 20 0 80) (q/curve-vertex 0 0 0) (q/curve-vertex 0 0 0) (q/end-shape :close))",
+  "((q/camera 50 200 50 50 0 0 0 0 1) (comment \"draw first shape\") (q/begin-shape) (q/curve-vertex 0 0) (q/curve-vertex 0 0) (q/curve-vertex 100 20) (q/curve-vertex 100 80) (q/curve-vertex 20 80) (q/curve-vertex 0 0) (q/curve-vertex 0 0) (q/end-shape :close) (comment \"draw second shape\") (q/begin-shape) (q/curve-vertex 0 0 0) (q/curve-vertex 0 0 0) (q/curve-vertex 100 0 20) (q/curve-vertex 100 0 80) (q/curve-vertex 20 0 80) (q/curve-vertex 0 0 0) (q/curve-vertex 0 0 0) (q/end-shape :close))",
   :setup "()",
   :target :cljs}
  {:fns ["bezier-vertex"],
@@ -707,7 +695,7 @@
   :name "bezier-vertex",
   :opts {:renderer :p3d, :settings nil},
   :draw
-  "((q/camera -400 250 -100 500 250 0 0 0 1) (q/begin-shape) (q/vertex 30 20) (q/bezier-vertex 480 0 480 475 30 475) (q/bezier-vertex 250 380 360 125 30 20) (q/end-shape :close) (q/begin-shape) (q/vertex 30 20 0) (q/bezier-vertex 480 0 20 480 475 30 30 475 40) (q/bezier-vertex 250 380 40 360 125 10 30 20 0) (q/end-shape :close))",
+  "((q/camera -400 250 -100 500 250 0 0 0 1) (comment \"draw first shape\") (q/begin-shape) (q/vertex 30 20) (q/bezier-vertex 480 0 480 475 30 475) (q/bezier-vertex 250 380 360 125 30 20) (q/end-shape :close) (comment \"draw second shape\") (q/begin-shape) (q/vertex 30 20 0) (q/bezier-vertex 480 0 20 480 475 30 30 475 40) (q/bezier-vertex 250 380 40 360 125 10 30 20 0) (q/end-shape :close))",
   :setup "()",
   :target :cljs}
  {:fns ["begin-shape" "end-shape"],
@@ -723,7 +711,23 @@
   :name "begin-shape-end-shape",
   :opts {:renderer :p2d, :settings nil},
   :draw
-  "((q/stroke 255 0 0) (doseq [[ind begin-mode close-mode] [[0 nil nil] [1 nil :close] [2 :points] [3 :lines] [4 :triangles] [5 :triangle-fan] [6 :triangle-strip] [7 :quads] [8 :quad-strip]] :let [base-x (* 150 (mod ind 3)) base-y (* 150 (quot ind 3))]] (if begin-mode (q/begin-shape begin-mode) (q/begin-shape)) (q/vertex (+ base-x 50) (+ base-y 10)) (q/vertex (+ base-x 80) (+ base-y 30)) (q/vertex (+ base-x 80) (+ base-y 70)) (q/vertex (+ base-x 50) (+ base-y 90)) (q/vertex (+ base-x 20) (+ base-y 70)) (q/vertex (+ base-x 20) (+ base-y 30)) (if close-mode (q/end-shape close-mode) (q/end-shape))))",
+  "((q/stroke 255 0 0) (comment \"try all kinds of begin modes\") (doseq [[ind begin-mode close-mode] [[0 nil nil] [1 nil :close] [2 :points] [3 :lines] [4 :triangles] [5 :triangle-fan] [6 :triangle-strip] [7 :quads] [8 :quad-strip]] :let [base-x (* 150 (mod ind 3)) base-y (* 150 (quot ind 3))]] (if begin-mode (q/begin-shape begin-mode) (q/begin-shape)) (q/vertex (+ base-x 50) (+ base-y 10)) (q/vertex (+ base-x 80) (+ base-y 30)) (q/vertex (+ base-x 80) (+ base-y 70)) (q/vertex (+ base-x 50) (+ base-y 90)) (q/vertex (+ base-x 20) (+ base-y 70)) (q/vertex (+ base-x 20) (+ base-y 30)) (if close-mode (q/end-shape close-mode) (q/end-shape))))",
+  :setup "()",
+  :target :cljs}
+ {:fns ["begin-contour" "end-contour"],
+  :ns "quil.snippets.shape.vertex",
+  :name "begin-contour-end-contour",
+  :opts {:renderer :p2d, :settings nil},
+  :draw
+  "((q/stroke 255 0 0) (q/fill 0 127 0) (q/begin-shape) (comment \"outer shape\") (q/vertex 250 20) (q/vertex 400 400) (q/vertex 50 400) (comment \"inner shape\") (q/begin-contour) (q/vertex 200 200) (q/vertex 250 380) (q/vertex 300 200) (q/end-contour) (q/end-shape :close))",
+  :setup "()",
+  :target :cljs}
+ {:fns ["clear"],
+  :ns "quil.snippets.color.setting",
+  :name "clear",
+  :opts {:renderer :p2d, :settings nil},
+  :draw
+  "((comment \"reusing the same graphics to draw 3 things\") (let [g (q/create-graphics 200 200 :p2d)] (q/background 255) (comment \"draw red square\") (q/with-graphics g (q/fill 255 0 0) (q/rect 25 25 150 150)) (q/image g 0 0) (comment \"draw circle without clearing\") (comment \"red square is still present\") (q/with-graphics g (q/fill 0 255 0) (q/ellipse 100 100 150 150)) (q/image g 50 50) (comment \"draw triangle but with clear\") (q/with-graphics g (q/clear) (q/fill 0 0 255) (q/triangle 25 25 175 25 25 175)) (q/image g 100 100)))",
   :setup "()",
   :target :cljs}
  {:fns ["stroke"],
@@ -731,7 +735,7 @@
   :name "stroke",
   :opts {:settings nil},
   :draw
-  "((q/background 255) (q/stroke-weight 10) (comment \"grey\") (q/stroke 120) (q/rect 0 0 100 100) (comment \"semitransparent light grey\") (q/stroke 80 120) (q/rect 70 70 100 100) (comment \"green\") (q/stroke 0 255 0) (q/rect 140 140 100 100) (comment \"semitransparent red\") (q/stroke 255 0 0 120) (q/rect 210 210 100 100))",
+  "((q/background 255) (q/stroke-weight 10) (comment \"grey\") (q/stroke 120) (q/rect 10 10 100 100) (comment \"semitransparent light grey\") (q/stroke 80 120) (q/rect 80 80 100 100) (comment \"green\") (q/stroke 0 255 0) (q/rect 150 150 100 100) (comment \"semitransparent red\") (q/stroke 255 0 0 120) (q/rect 220 220 100 100))",
   :setup "()",
   :target :cljs}
  {:fns ["no-stroke"],
@@ -739,7 +743,7 @@
   :name "no-stroke",
   :opts {:settings nil},
   :draw
-  "((q/background 255) (comment \"set stroke to black\") (q/fill 120) (q/stroke 0) (q/rect 0 0 100 100) (comment \"remove stroke, no border around square\") (q/no-stroke) (q/rect 70 70 100 100))",
+  "((q/background 255) (q/stroke-weight 10) (comment \"set stroke to black\") (q/fill 120) (q/stroke 0) (q/rect 30 30 100 100) (comment \"remove stroke, no border around square\") (q/no-stroke) (q/rect 100 100 100 100))",
   :setup "()",
   :target :cljs}
  {:fns ["no-fill"],
@@ -765,7 +769,7 @@
   :draw
   "((let [im (q/state :image)] (comment \"check if image is loaded by checking its size matches sketch size\") (when (= (.-width im) (q/width)) (q/background-image im))))",
   :setup
-  "(let [size (str (q/width) \"x\" (q/height)) _ (comment \"create url to image to used as background\") url (str \"https://dummyimage.com/\" size \"/2c3e50/ffffff.png\")] (q/set-state! :image (q/load-image url)))",
+  "(let [_ (comment \"create url to image to used as background\") url (str \"https://placekitten.com/\" (q/width) \"/\" (q/height))] (q/set-state! :image (q/load-image url)))",
   :target :cljs}
  {:fns ["background"],
   :ns "quil.snippets.color.setting",
@@ -775,42 +779,20 @@
   "((comment \"red\") (q/background 255 0 0) (let [_ (comment \"create graphics to test backgrounds\") gr (q/create-graphics 100 100)] (q/with-graphics gr (comment \"grey\") (q/background 120)) (q/image gr 0 0) (q/with-graphics gr (comment \"light-grey transparent\") (q/background 70 120)) (q/image gr 70 70) (q/with-graphics gr (comment \"cyan\") (q/background 0 255 255)) (q/image gr 140 140) (q/with-graphics gr (comment \"semitransparent blue\") (q/background 0 0 255 120)) (q/image gr 210 210)))",
   :setup "()",
   :target :cljs}
- {:fns ["print-projection"],
+ {:fns ["ortho" "perspective"],
   :ns "quil.snippets.lights-camera.camera",
-  :name "print-projection",
-  :opts {:renderer :p3d, :settings nil},
-  :draw "((q/print-projection))",
-  :setup "()",
-  :target :cljs}
- {:fns ["print-camera"],
-  :ns "quil.snippets.lights-camera.camera",
-  :name "print-camera",
-  :opts {:renderer :p3d, :settings nil},
-  :draw "((q/print-camera))",
-  :setup "()",
-  :target :cljs}
- {:fns ["perspective"],
-  :ns "quil.snippets.lights-camera.camera",
-  :name "perspective",
-  :opts {:renderer :p2d, :settings nil},
-  :draw
-  "((let [perspective-params [[] [(/ q/PI 2) 0.5 50 300]] pos [[0 0] [250 0] [127 250]]] (dotimes [ind (count perspective-params)] (let [gr (q/create-graphics 240 240 :p3d)] (q/with-graphics gr (q/background 255) (q/camera 100 100 100 0 0 0 0 0 -1) (apply q/perspective (nth perspective-params ind)) (q/fill 127) (q/box 100)) (apply q/image gr (nth pos ind))))))",
-  :setup "()",
-  :target :cljs}
- {:fns ["ortho"],
-  :ns "quil.snippets.lights-camera.camera",
-  :name "ortho",
-  :opts {:renderer :p2d, :settings nil},
-  :draw
-  "((let [ortho-params [[] [0 300 0 300] [0 300 0 300 0 170]] pos [[0 0] [250 0] [127 250]]] (dotimes [ind (count ortho-params)] (let [gr (q/create-graphics 240 240 :p3d)] (q/with-graphics gr (q/background 255) (q/camera 100 100 100 0 0 0 0 0 -1) (apply q/ortho (nth ortho-params ind)) (q/fill 127) (q/box 100)) (apply q/image gr (nth pos ind))))))",
-  :setup "()",
-  :target :cljs}
- {:fns ["frustum"],
-  :ns "quil.snippets.lights-camera.camera",
-  :name "frustum",
+  :name "ortho-perspective",
   :opts {:renderer :p3d, :settings nil},
   :draw
-  "((q/background 255) (q/camera 200 200 200 0 0 0 0 0 -1) (q/frustum -100 100 -100 100 200 330) (q/stroke-weight 2) (q/stroke 0) (q/fill 127) (q/box 100) (q/stroke 255 0 0) (q/line 0 0 0 100 0 0) (q/stroke 0 255 0) (q/line 0 0 0 0 100 0) (q/stroke 0 0 255) (q/line 0 0 0 0 0 100))",
+  "((q/background 240) (comment \"flip between ortho and perspective camera every frame\") (comment \"enable ortho camera\") (comment \"in ortho all figures will look the same regardless distance\") (comment \"in perspective (default) all figures will look smaller the farther they are\") (if (even? (q/frame-count)) (q/ortho) (q/perspective)) (comment \"set camera to look from [300, 0, 300] at point [100, 0, 0]\") (q/camera 300 0 300 100 0 0 0 0 -1) (q/fill 0 127 127) (comment \"draw 3 boxes with x coordinates 0, 100 and 200\") (doseq [x [0 100 200]] (q/with-translation [x 0 0] (q/box 50))))",
+  :setup "(q/frame-rate 1)",
+  :target :cljs}
+ {:fns ["orbit-control"],
+  :ns "quil.snippets.lights-camera.camera",
+  :name "orbit-control",
+  :opts {:renderer :p3d, :settings nil},
+  :draw
+  "((q/orbit-control) (q/background 255) (q/fill 0 127 127) (q/box 200) (comment \"rotate camera around box using mouse\"))",
   :setup "()",
   :target :cljs}
  {:fns ["camera"],
@@ -818,15 +800,7 @@
   :name "camera",
   :opts {:renderer :p3d, :settings nil},
   :draw
-  "((q/background 255) (q/camera 200 200 200 0 0 0 0 0 -1) (q/stroke-weight 2) (q/stroke 0) (q/fill 127) (q/box 100) (q/stroke 255 0 0) (q/line 0 0 0 100 0 0) (q/stroke 0 255 0) (q/line 0 0 0 0 100 0) (q/stroke 0 0 255) (q/line 0 0 0 0 0 100))",
-  :setup "()",
-  :target :cljs}
- {:fns ["begin-camera" "end-camera" "camera"],
-  :ns "quil.snippets.lights-camera.camera",
-  :name "begin-camera-end-camera-camera",
-  :opts {:renderer :p3d, :settings nil},
-  :draw
-  "((q/background 255) (q/begin-camera) (q/camera) (q/translate 250 0 -250) (q/rotate-z (/ q/PI 4)) (q/rotate-x (/ q/PI 8)) (q/rotate-y (/ q/PI -8)) (q/end-camera) (q/stroke-weight 2) (q/stroke 0) (q/fill 127) (q/box 100) (q/stroke 255 0 0) (q/line 0 0 0 100 0 0) (q/stroke 0 255 0) (q/line 0 0 0 0 100 0) (q/stroke 0 0 255) (q/line 0 0 0 0 0 100))",
+  "((q/background 255) (comment \"set camera in point [200, 200, 200]\") (comment \"the camera looks in direction of point [0, 0, 0]\") (comment \"\\\"up\\\" vector is [0, 0, -1]\") (q/camera 200 200 200 0 0 0 0 0 -1) (comment \"draw a box of size 100 at the [0, 0, 0] point\") (q/stroke-weight 2) (q/stroke 0) (q/fill 127) (q/box 100) (comment \"draw red X axis\") (q/stroke 255 0 0) (q/line 0 0 0 100 0 0) (comment \"draw green Y axis\") (q/stroke 0 255 0) (q/line 0 0 0 0 100 0) (comment \"draw blue Z axis\") (q/stroke 0 0 255) (q/line 0 0 0 0 0 100))",
   :setup "()",
   :target :cljs}
  {:fns ["triangle"],
@@ -842,7 +816,7 @@
   :name "rect",
   :opts {:settings nil},
   :draw
-  "((q/background 255) (q/fill 220 200 255) (q/rect 50 50 150 100) (q/rect 300 50 150 100 20) (q/rect 50 300 150 100 5 10 20 30))",
+  "((q/background 255) (q/fill 220 200 255) (comment \"normal rect\") (q/rect 50 50 150 100) (comment \"rect with rounded corners\") (q/rect 300 50 150 100 20) (comment \"rect with rounded corners where each corner is different\") (q/rect 50 300 150 100 5 10 20 30))",
   :setup "()",
   :target :cljs}
  {:fns ["quad"],
@@ -858,7 +832,7 @@
   :name "point",
   :opts {:renderer :p3d, :settings nil},
   :draw
-  "((q/background 255) (q/stroke-weight 10) (q/stroke 255 0 0) (q/point 10 10) (q/stroke 0 0 255) (q/point 50 50 -200))",
+  "((q/background 255) (q/stroke-weight 10) (comment \"red ponit\") (q/stroke 255 0 0) (q/point 10 10) (comment \"blue point\") (q/stroke 0 0 255) (q/point 50 50 -200))",
   :setup "()",
   :target :cljs}
  {:fns ["line"],
@@ -866,7 +840,7 @@
   :name "line",
   :opts {:renderer :p3d, :settings nil},
   :draw
-  "((q/background 255) (q/camera 250 250 250 0 0 0 0 0 -1) (q/stroke 255 0 0) (q/line [0 0] [100 100]) (q/stroke 0 255 0) (q/line 100 0 0 100) (q/stroke 0 0 255) (q/line 0 0 0 170 120 100) (q/line 170 120 100 50 -50 20) (q/line 50 -50 20 0 0 0))",
+  "((q/background 255) (q/camera 250 250 250 0 0 0 0 0 -1) (comment \"red line\") (q/stroke 255 0 0) (q/line [0 0] [100 100]) (comment \"green line\") (q/stroke 0 255 0) (q/line 100 0 0 100) (comment \"three blue lines\") (q/stroke 0 0 255) (q/line 0 0 0 170 120 100) (q/line 170 120 100 50 -50 20) (q/line 50 -50 20 0 0 0))",
   :setup "()",
   :target :cljs}
  {:fns ["ellipse"],
@@ -882,7 +856,7 @@
   :name "arc",
   :opts {:settings nil},
   :draw
-  "((q/background 255) (q/stroke 0) (q/fill 220 200 255) (q/arc 50 100 200 170 0 q/QUARTER-PI) (doseq [[ind mode] [[0 :open] [1 :chord] [2 :pie]]] (q/arc (+ 50 (* ind 150)) 300 200 170 0 q/QUARTER-PI)))",
+  "((q/background 255) (q/stroke 0) (q/fill 220 200 255) (comment \"draw default arc\") (q/arc 50 100 200 170 0 q/QUARTER-PI) (comment \"draw different arc modes\") (doseq [[ind mode] [[0 :open] [1 :chord] [2 :pie]]] (q/arc (+ 50 (* ind 150)) 300 200 170 0 q/QUARTER-PI mode)))",
   :setup "()",
   :target :cljs}
  {:fns ["tan"],
@@ -949,6 +923,14 @@
   "((q/background 255) (q/fill 0) (q/text (str \"(q/asin 0) = \" (q/asin 0)) 10 20) (q/text (str \"(q/asin 1) = \" (q/asin 1)) 10 40))",
   :setup "()",
   :target :cljs}
+ {:fns ["angle-mode"],
+  :ns "quil.snippets.math.trigonometry",
+  :name "angle-mode",
+  :opts {:settings nil},
+  :draw
+  "((comment \"draw a red square for reference\") (q/fill 255 0 0) (q/rect 0 0 100 100) (comment \"rotation will be in degrees (instead of the default radians)\") (q/angle-mode :degrees) (q/rotate 45) (comment \"draw a green square after the rotation of 45 degrees\") (q/fill 0 255 0) (q/rect 0 0 100 100))",
+  :setup "()",
+  :target :cljs}
  {:fns ["acos"],
   :ns "quil.snippets.math.trigonometry",
   :name "acos",
@@ -957,44 +939,12 @@
   "((q/background 255) (q/fill 0) (q/text (str \"(q/acos 0) = \" (q/acos 0)) 10 20) (q/text (str \"(q/acos 1) = \" (q/acos 1)) 10 40))",
   :setup "()",
   :target :cljs}
- {:fns ["screen-x" "screen-y" "screen-z"],
-  :ns "quil.snippets.lights-camera.coordinates",
-  :name "screen-x-y-z",
-  :opts {:renderer :p2d, :settings nil},
-  :draw
-  "((let [gr3d (q/create-graphics 240 240 :p3d) gr-text (q/create-graphics 240 240 :java2d)] (q/with-graphics gr3d (q/background 255) (q/camera 13 25 50 0 0 0 0 0 -1) (q/stroke-weight 2) (q/stroke 255 0 0) (q/line 0 0 0 20 0 0) (q/stroke 0 255 0) (q/line 0 0 0 0 20 0) (q/stroke 0 0 255) (q/line 0 0 0 0 0 20) (q/stroke 255 0 0) (q/stroke-weight 7) (q/point 0 0 0) (q/point 10 5 7) (let [x1 (q/screen-x 0 0) x2 (q/screen-x 10 5 7) y1 (q/screen-y 0 0) y2 (q/screen-y 10 5 7) z1 (q/model-z 0 0 0) z2 (q/model-z 10 5 7)] (q/with-graphics gr-text (q/background 255) (q/fill 0) (doseq [[ind capt val] [[1 \"(q/screen-x 0 0)\" x1] [2 \"(q/screen-x 10 5 6)\" x2] [3 \"(q/screen-y 0 0)\" y1] [4 \"(q/screen-y 10 5 6)\" y2] [5 \"(q/screen-z 0 0 0)\" x1] [6 \"(q/screen-z 10 5 6)\" z2]]] (q/text (str capt \" is \" val) 20 (* ind 20)))))) (q/image gr3d 0 0) (q/image gr-text 250 0)))",
-  :setup "()",
-  :target :cljs}
- {:fns ["model-x" "model-y" "model-z"],
-  :ns "quil.snippets.lights-camera.coordinates",
-  :name "model-x-y-z",
-  :opts {:renderer :p2d, :settings nil},
-  :draw
-  "((let [gr3d (q/create-graphics 240 240 :p3d) gr-text (q/create-graphics 240 240 :java2d)] (q/with-graphics gr3d (q/background 255) (q/camera 50 25 13 0 0 0 0 0 -1) (q/stroke-weight 2) (q/stroke 255 0 0) (q/line 0 0 0 20 0 0) (q/stroke 0 255 0) (q/line 0 0 0 0 20 0) (q/stroke 0 0 255) (q/line 0 0 0 0 0 20) (q/stroke 255 0 0) (q/stroke-weight 5) (q/translate 10 20 5) (q/point 0 0 0) (let [x (q/model-x 0 0 0) y (q/model-y 0 0 0) z (q/model-z 0 0 0)] (q/with-graphics gr-text (q/background 255) (q/fill 0) (doseq [[ind capt val] [[1 \"(q/model-x 0 0 0)\" x] [2 \"(q/model-y 0 0 0)\" y] [3 \"(q/model-z 0 0 0)\" z]]] (q/text (str capt \" is \" val) 20 (* ind 20)))))) (q/image gr3d 0 0) (q/image gr-text 250 0)))",
-  :setup "()",
-  :target :cljs}
  {:fns ["specular"],
   :ns "quil.snippets.lights-camera.material-properties",
   :name "specular",
   :opts {:renderer :p3d, :settings nil},
   :draw
-  "((q/background 0) (q/camera 150 150 150 0 25 0 0 0 -1) (q/no-stroke) (q/fill 0 51 102) (q/light-specular 255 255 255) (q/directional-light 204 204 204 -1 -1 -1) (q/specular 255) (q/sphere 50) (q/translate 0 100 0) (q/specular 204 102 0) (q/sphere 40))",
-  :setup "()",
-  :target :cljs}
- {:fns ["shininess"],
-  :ns "quil.snippets.lights-camera.material-properties",
-  :name "shininess",
-  :opts {:renderer :p3d, :settings nil},
-  :draw
-  "((q/background 0) (q/camera 150 150 150 0 25 0 0 0 -1) (q/fill 127 0 255) (q/no-stroke) (q/light-specular 204 204 204) (q/directional-light 102 102 102 -1 -1 -1) (q/specular 255 255 255) (q/shininess 2) (q/sphere 50) (q/translate 0 100 0) (q/shininess 10) (q/sphere 40))",
-  :setup "()",
-  :target :cljs}
- {:fns ["emissive"],
-  :ns "quil.snippets.lights-camera.material-properties",
-  :name "emissive",
-  :opts {:renderer :p3d, :settings nil},
-  :draw
-  "((q/background 0) (q/camera 150 150 150 0 0 0 0 0 -1) (q/ambient-light 255 127 127) (q/emissive 0 0 255) (q/box 100) (q/translate 0 100 0) (q/emissive (q/color 0 127 0)) (q/sphere 40))",
+  "((q/fill 255) (q/background 0) (q/camera 150 150 150 0 25 0 0 0 -1) (q/ambient-light 60 60 60) (q/no-stroke) (q/point-light 25 255 255 150 150 150) (q/specular 255) (q/sphere 50) (q/translate 0 100 0) (q/specular 204 0 0) (q/sphere 40))",
   :setup "()",
   :target :cljs}
  {:fns ["ambient"],
@@ -1002,7 +952,7 @@
   :name "ambient",
   :opts {:renderer :p3d, :settings nil},
   :draw
-  "((q/background 0) (q/camera 150 150 150 0 0 0 0 0 -1) (q/ambient-light 255 127 127) (q/ambient 255 127 0) (q/box 100) (q/translate 0 100 0) (q/ambient 127) (q/sphere 40))",
+  "((q/background 0) (q/camera 150 150 150 0 0 0 0 0 -1) (comment \"set light to kinda pink\") (q/ambient-light 255 127 127) (comment \"first box has full reflectance\") (q/ambient 255) (q/translate 0 -50 0) (q/box 50) (comment \"second box has abmient material with blue-only component\") (q/translate 0 75 0) (q/ambient 0 0 255) (q/box 50) (comment \"third box has gray ambient material\") (q/translate 0 75 0) (q/ambient 127) (q/box 50))",
   :setup "()",
   :target :cljs}
  {:fns ["with-stroke"],
@@ -1098,7 +1048,7 @@
   :name "resize-image",
   :opts {:settings nil},
   :draw
-  "((comment \"create image and draw gradient on it\") (let [im (q/create-image 100 100 :rgb)] (dotimes [x 100] (dotimes [y 100] (q/set-pixel im x y (q/color (* 2 x) (* 2 y) (+ x y))))) (q/image im 0 0) (comment \"resize image from 100x100 to 50x50 and draw again\") (q/resize im 50 50) (q/image im 100 100)))",
+  "((comment \"create image and draw gradient on it\") (let [im (q/create-image 100 100)] (dotimes [x 100] (dotimes [y 100] (q/set-pixel im x y (q/color (* 2 x) (* 2 y) (+ x y))))) (q/update-pixels im) (q/image im 0 0) (comment \"resize image from 100x100 to 50x50 and draw again\") (q/resize im 50 50) (q/image im 100 100)))",
   :setup "()",
   :target :cljs}
  {:fns ["create-image" "set-pixel"],
@@ -1106,14 +1056,31 @@
   :name "create-image",
   :opts {:settings nil},
   :draw
-  "((q/background 255) (comment \"create image and draw gradient on it\") (let [im (q/create-image 100 100 :rgb)] (dotimes [x 100] (dotimes [y 100] (q/set-pixel im x y (q/color (* 2 x) (* 2 y) (+ x y))))) (comment \"draw image twice\") (q/image im 0 0) (q/image im 50 50)))",
+  "((q/background 255) (comment \"create image and draw gradient on it\") (let [im (q/create-image 100 100)] (dotimes [x 100] (dotimes [y 100] (q/set-pixel im x y (q/color (* 2 x) (* 2 y) (+ x y))))) (q/update-pixels im) (comment \"draw image twice\") (q/image im 0 0) (q/image im 50 50)))",
   :setup "()",
   :target :cljs}
- {:fns ["no-cursor"],
+ {:fns ["resize-sketch"],
   :ns "quil.snippets.environment",
-  :name "no-cursor",
+  :name "resize-sketch",
   :opts {:settings nil},
-  :draw "((q/no-cursor))",
+  :draw
+  "((q/frame-rate 1) (comment \"each frame increase size of sketch\") (q/resize-sketch (inc (q/width)) (inc (q/height))) (q/background 255) (q/fill 0) (q/text (str \"width: \" (q/width) \", height: \" (q/height)) 10 20))",
+  :setup "()",
+  :target :cljs}
+ {:fns ["pixel-density"],
+  :ns "quil.snippets.environment",
+  :name "pixel-density",
+  :opts {:settings nil},
+  :draw
+  "((q/background 255) (q/fill 0) (q/ellipse 102 102 200 200) (q/triangle 200 200 400 300 300 400))",
+  :setup "()",
+  :target :cljs}
+ {:fns ["display-density"],
+  :ns "quil.snippets.environment",
+  :name "display-density",
+  :opts {:settings nil},
+  :draw
+  "((q/background 255) (q/fill 0) (q/text (str \"display density: \" (q/display-density)) 10 20))",
   :setup "()",
   :target :cljs}
  {:fns ["height" "width"],
@@ -1121,7 +1088,7 @@
   :name "height-width",
   :opts {:settings nil},
   :draw
-  "((q/background 255) (q/fill 0) (q/text (str (q/width) \"x\" (q/height)) 10 20))",
+  "((q/background 255) (q/fill 0) (q/text (str \"width: \" (q/width) \", height: \" (q/height)) 10 20))",
   :setup "()",
   :target :cljs}
  {:fns ["frame-rate"],
@@ -1129,7 +1096,7 @@
   :name "frame-rate",
   :opts {:settings nil},
   :draw
-  "((q/background 255) (q/fill 0) (q/text (str (q/target-frame-rate)) 10 20) (q/frame-rate (inc (rand-int 5))))",
+  "((q/background 255) (q/fill 0) (q/text (str \"Frame rate: \" (q/target-frame-rate)) 10 20) (let [frame (q/frame-count)] (comment \"draw moving box\") (q/rect (rem frame (q/width)) 50 50 50) (comment \"every 10 frames change frame rate\") (comment \"frame rate cycles through [1, 6, 11, 16, 21]\") (when (zero? (rem frame 10)) (q/frame-rate (inc (* 5 (rem (quot frame 10) 5)))))))",
   :setup "()",
   :target :cljs}
  {:fns ["frame-count"],
@@ -1137,7 +1104,7 @@
   :name "frame-count",
   :opts {:settings nil},
   :draw
-  "((q/background 255) (q/fill 0) (q/text (str (q/frame-count)) 10 20))",
+  "((q/background 255) (q/fill 0) (q/text (str \"Frame count: \" (q/frame-count)) 10 20))",
   :setup "()",
   :target :cljs}
  {:fns ["focused"],
@@ -1145,23 +1112,15 @@
   :name "focused",
   :opts {:settings nil},
   :draw
-  "((q/background 255) (q/fill 0) (q/text (str (q/focused)) 10 20))",
+  "((q/background 255) (q/fill 0) (q/text (str \"Focused: \" (q/focused)) 10 20))",
   :setup "()",
   :target :cljs}
- {:fns ["cursor-image"],
+ {:fns ["cursor" "no-cursor"],
   :ns "quil.snippets.environment",
-  :name "cursor-image",
+  :name "cursor-no-cursor",
   :opts {:settings nil},
   :draw
-  "((if (zero? (.-width (q/state :image))) (q/text \"Loading\" 10 10) (do (q/cursor-image (q/state :image)) (q/cursor-image (q/state :image) 16 16) (q/image (q/state :image) 0 0))))",
-  :setup "(q/set-state! :image (q/request-image \"cursor.jpg\"))",
-  :target :cljs}
- {:fns ["cursor"],
-  :ns "quil.snippets.environment",
-  :name "cursor",
-  :opts {:settings nil},
-  :draw
-  "((q/no-cursor) (q/cursor) (doseq [type [:arrow :cross :hand :move :text :wait]] (q/cursor type)))",
+  "((q/background 255) (q/rect-mode :corners) (q/text-align :center :center) (comment \"iterate through all types of cursors\") (let [types [:arrow :cross :hand :move :text :wait :no-cursor :default] box-width (/ (q/width) 4.1) box-height (/ (q/height) 2.1)] (dotimes [ind (count types)] (let [type (nth types ind) _ (comment \"calculate corners of current box\") x (* box-width (rem ind 4)) y (* box-height (quot ind 4)) n-x (+ x box-width) n-y (+ y box-height)] (comment \"draw a box for current type with its name in center\") (q/stroke 127) (q/no-fill) (q/rect x y n-x n-y) (q/no-stroke) (q/fill 0) (q/text (str type) (/ (+ x n-x) 2) (/ (+ y n-y) 2)) (comment \"if mouse is inside the box - enable this type\") (when (and (<= x (q/mouse-x) n-x) (<= y (q/mouse-y) n-y)) (condp = type :default (q/cursor) :no-cursor (q/no-cursor) (q/cursor type)))))))",
   :setup "()",
   :target :cljs}
  {:fns ["current-graphics"],
@@ -1177,7 +1136,7 @@
   :name "current-frame-rate-target-frame-rate",
   :opts {:settings nil},
   :draw
-  "((q/background 255) (q/fill 0) (q/text (str (q/current-frame-rate)) 10 20) (q/text (str (q/target-frame-rate)) 10 40))",
+  "((q/background 255) (q/fill 0) (q/text (str \"(q/current-frame-rate) = \" (q/current-frame-rate)) 10 20) (q/text (str \"(q/target-frame-rate) = \" (q/target-frame-rate)) 10 40))",
   :setup "()",
   :target :cljs}
  {:fns ["with-translation"],
@@ -1185,7 +1144,7 @@
   :name "with-translation-3d",
   :opts {:renderer :p3d, :settings nil},
   :draw
-  "((q/background 255) (q/stroke 0) (comment \"set camera and draw XYZ axis\") (q/camera 200 200 200 0 0 0 0 0 -1) (q/line 0 0 0 100 0 0) (q/line 0 0 0 0 100 0) (q/line 0 0 0 0 0 100) (q/fill 0) (q/text \"x\" 100 0 0) (q/text \"y\" 0 100 0) (q/text \"z\" 0 0 100) (q/no-fill) (q/stroke 255 0 0) (comment \"draw 3 boxes using with-translation\") (q/box 50) (q/with-translation [100 0 0] (q/box 50)) (q/with-translation [100 0 100] (q/box 50)))",
+  "((q/background 255) (q/stroke 0) (comment \"set camera and draw XYZ axis\") (q/camera 200 200 200 0 0 0 0 0 -1) (q/line 0 0 0 100 0 0) (q/line 0 0 0 0 100 0) (q/line 0 0 0 0 0 100) (q/fill 0) (q/no-fill) (q/stroke 255 0 0) (comment \"draw 3 boxes using with-translation\") (q/box 50) (q/with-translation [100 0 0] (q/box 50)) (q/with-translation [100 0 100] (q/box 50)))",
   :setup "()",
   :target :cljs}
  {:fns ["with-translation"],
@@ -1201,7 +1160,7 @@
   :name "with-rotation-3d-around-xy",
   :opts {:renderer :p3d, :settings nil},
   :draw
-  "((q/background 255) (q/stroke 0) (comment \"set camera and draw XYZ axis\") (q/camera 200 200 200 0 0 0 0 0 -1) (q/line 0 0 0 100 0 0) (q/line 0 0 0 0 100 0) (q/line 0 0 0 0 0 100) (q/fill 0) (q/text \"x\" 100 0 0) (q/text \"y\" 0 100 0) (q/text \"z\" 0 0 100) (q/no-fill) (q/stroke 255 0 0) (comment \"draw box without rotation\") (q/box 50) (comment \"draw box with 45° rotation around \") (comment \"[1, 1, 0] vector.\") (q/with-translation [100 0 0] (q/with-rotation [(/ q/PI 4) 1 1 0] (q/box 50))))",
+  "((q/background 255) (q/stroke 0) (comment \"set camera and draw XYZ axis\") (q/camera 200 200 200 0 0 0 0 0 -1) (q/line 0 0 0 100 0 0) (q/line 0 0 0 0 100 0) (q/line 0 0 0 0 0 100) (q/fill 0) (q/no-fill) (q/stroke 255 0 0) (comment \"draw box without rotation\") (q/box 50) (comment \"draw box with 45° rotation around \") (comment \"[1, 1, 0] vector.\") (q/with-translation [100 0 0] (q/with-rotation [(/ q/PI 4) 1 1 0] (q/box 50))))",
   :setup "()",
   :target :cljs}
  {:fns ["with-rotation"],
@@ -1209,7 +1168,7 @@
   :name "with-rotation-3d-around-x",
   :opts {:renderer :p3d, :settings nil},
   :draw
-  "((q/background 255) (q/stroke 0) (comment \"set camera and draw XYZ axis\") (q/camera 200 200 200 0 0 0 0 0 -1) (q/line 0 0 0 100 0 0) (q/line 0 0 0 0 100 0) (q/line 0 0 0 0 0 100) (q/fill 0) (q/text \"x\" 100 0 0) (q/text \"y\" 0 100 0) (q/text \"z\" 0 0 100) (q/no-fill) (q/stroke 255 0 0) (comment \"draw box without rotation\") (q/box 50) (comment \"draw box with 45° rotation around \") (comment \"[1, 0, 0] vector.\") (q/with-translation [100 0 0] (q/with-rotation [(/ q/PI 4) 1 0 0] (q/box 50))))",
+  "((q/background 255) (q/stroke 0) (comment \"set camera and draw XYZ axis\") (q/camera 200 200 200 0 0 0 0 0 -1) (q/line 0 0 0 100 0 0) (q/line 0 0 0 0 100 0) (q/line 0 0 0 0 0 100) (q/fill 0) (q/no-fill) (q/stroke 255 0 0) (comment \"draw box without rotation\") (q/box 50) (comment \"draw box with 45° rotation around \") (comment \"[1, 0, 0] vector.\") (q/with-translation [100 0 0] (q/with-rotation [(/ q/PI 4) 1 0 0] (q/box 50))))",
   :setup "()",
   :target :cljs}
  {:fns ["with-rotation"],
@@ -1225,7 +1184,7 @@
   :name "curve-tightness",
   :opts {:settings nil},
   :draw
-  "((q/no-fill) (doseq [[ind t] [[0 -5] [1 -1] [2 0] [3 1] [4 5]]] (q/curve-tightness t) (q/with-translation [100 (+ 50 (* ind 70))] (q/curve 0 0 0 0 50 30 100 -30) (q/curve 0 0 50 30 100 -30 150 0) (q/curve 50 30 100 -30 150 0 150 0))))",
+  "((q/no-fill) (comment \"try different tightnesses\") (doseq [[ind t] [[0 -5] [1 -1] [2 0] [3 1] [4 5]]] (q/curve-tightness t) (q/with-translation [100 (+ 50 (* ind 70))] (q/curve 0 0 0 0 50 30 100 -30) (q/curve 0 0 50 30 100 -30 150 0) (q/curve 50 30 100 -30 150 0 150 0))))",
   :setup "()",
   :target :cljs}
  {:fns ["curve-tangent"],
@@ -1233,7 +1192,7 @@
   :name "curve-tangent",
   :opts {:settings nil},
   :draw
-  "((q/fill 0) (dotimes [i 5] (let [v (/ i 4) res (q/curve-tangent 0 5 7 0 v) txt (str \"(q/bezier-point 0 5 7 0 \" v \") = \" res)] (q/text txt 10 (+ 20 (* i 20))))))",
+  "((comment \"see https://p5js.org/reference/#/p5/curveTangent for better example\") (q/fill 0) (dotimes [i 5] (let [v (/ i 4) res (q/curve-tangent 0 5 7 0 v) txt (str \"(q/curve-tangent 0 5 7 0 \" v \") = \" res)] (q/text txt 10 (+ 20 (* i 20))))))",
   :setup "()",
   :target :cljs}
  {:fns ["curve-point"],
@@ -1241,7 +1200,7 @@
   :name "curve-point",
   :opts {:settings nil},
   :draw
-  "((q/fill 0) (dotimes [i 5] (let [v (/ i 4) res (q/curve-point 0 5 7 0 v) txt (str \"(q/bezier-point 0 5 7 0 \" v \") = \" res)] (q/text txt 10 (+ 20 (* i 20))))))",
+  "((comment \"see https://p5js.org/reference/#/p5/curvePoint for better example\") (q/fill 0) (dotimes [i 5] (let [v (/ i 4) res (q/curve-point 0 5 7 0 v) txt (str \"(q/curve-point 0 5 7 0 \" v \") = \" res)] (q/text txt 10 (+ 20 (* i 20))))))",
   :setup "()",
   :target :cljs}
  {:fns ["curve-detail"],
@@ -1265,7 +1224,7 @@
   :name "bezier-tangent",
   :opts {:settings nil},
   :draw
-  "((q/fill 0) (dotimes [i 5] (let [v (/ i 4) res (q/bezier-tangent 0 5 7 0 v) txt (str \"(q/bezier-point 0 5 7 0 \" v \") = \" res)] (q/text txt 10 (+ 20 (* i 20))))))",
+  "((comment \"see https://p5js.org/reference/#/p5/bezierTangent for better example\") (q/fill 0) (dotimes [i 5] (let [v (/ i 4) res (q/bezier-tangent 0 5 7 0 v) txt (str \"(q/bezier-tangent 0 5 7 0 \" v \") = \" res)] (q/text txt 10 (+ 20 (* i 20))))))",
   :setup "()",
   :target :cljs}
  {:fns ["bezier-point"],
@@ -1273,23 +1232,15 @@
   :name "bezier-point",
   :opts {:settings nil},
   :draw
-  "((q/fill 0) (dotimes [i 5] (let [v (/ i 4) res (q/bezier-point 0 5 7 0 v) txt (str \"(q/bezier-point 0 5 7 0 \" v \") = \" res)] (q/text txt 10 (+ 20 (* i 20))))))",
+  "((comment \"see https://p5js.org/reference/#/p5/bezierPoint for better example\") (q/fill 0) (dotimes [i 5] (let [v (/ i 4) res (q/bezier-point 0 5 7 0 v) txt (str \"(q/bezier-point 0 5 7 0 \" v \") = \" res)] (q/text txt 10 (+ 20 (* i 20))))))",
   :setup "()",
   :target :cljs}
  {:fns ["bezier-detail"],
   :ns "quil.snippets.shape.curves",
-  :name "bezier-detail-3d",
+  :name "bezier-detail",
   :opts {:renderer :p3d, :settings nil},
   :draw
-  "((q/camera 0 0 300 0 0 0 0 1 0) (q/no-fill) (q/bezier-detail 20) (q/bezier 0 0 0 0 100 0 0 100 0 100 0 0))",
-  :setup "()",
-  :target :cljs}
- {:fns ["bezier-detail"],
-  :ns "quil.snippets.shape.curves",
-  :name "bezier-detail-2d",
-  :opts {:settings nil},
-  :draw
-  "((q/no-fill) (q/bezier-detail 5) (q/bezier 0 0 50 100 100 -100 150 0))",
+  "((q/camera 0 0 300 0 0 0 0 1 0) (q/no-fill) (q/bezier-detail 5) (q/bezier 0 0 0 0 100 0 0 100 0 100 0 0))",
   :setup "()",
   :target :cljs}
  {:fns ["bezier-3d"],
@@ -1304,7 +1255,8 @@
   :ns "quil.snippets.shape.curves",
   :name "bezier-2d",
   :opts {:settings nil},
-  :draw "((q/no-fill) (q/bezier 0 0 50 100 100 -100 150 0))",
+  :draw
+  "((q/no-fill) (q/with-translation [100 100] (q/bezier 0 0 50 100 100 -100 150 0)))",
   :setup "()",
   :target :cljs}
  {:fns ["stroke-weight"],
@@ -1320,7 +1272,7 @@
   :name "stroke-join",
   :opts {:settings nil},
   :draw
-  "((q/rect-mode :center) (q/stroke-weight 12) (q/stroke-join :miter) (q/rect 125 125 100 100) (q/stroke-join :bevel) (q/rect 375 125 100 100) (q/stroke-join :round) (q/rect 125 375 100 100))",
+  "((q/rect-mode :center) (q/stroke-weight 12) (comment \"use :miter join\") (q/stroke-join :miter) (q/rect 125 125 100 100) (comment \"use :bevel join\") (q/stroke-join :bevel) (q/rect 375 125 100 100) (comment \"use :round join\") (q/stroke-join :round) (q/rect 125 375 100 100))",
   :setup "()",
   :target :cljs}
  {:fns ["stroke-cap"],
@@ -1328,7 +1280,7 @@
   :name "stroke-cap",
   :opts {:settings nil},
   :draw
-  "((q/stroke-weight 12) (q/stroke-cap :square) (q/line 230 200 270 200) (q/stroke-cap :project) (q/line 230 250 270 250) (q/stroke-cap :round) (q/line 230 300 270 300))",
+  "((q/stroke-weight 12) (comment \"use :square cap\") (q/stroke-cap :square) (q/line 230 200 270 200) (comment \"use :project cap\") (q/stroke-cap :project) (q/line 230 250 270 250) (comment \"use :round cap\") (q/stroke-cap :round) (q/line 230 300 270 300))",
   :setup "()",
   :target :cljs}
  {:fns ["rect-mode"],
@@ -1336,14 +1288,15 @@
   :name "rect-mode",
   :opts {:settings nil},
   :draw
-  "((q/stroke-weight 5) (q/rect-mode :center) (q/with-translation [125 125] (q/stroke 0) (q/rect 0 0 100 70) (q/stroke 255 0 0) (q/point 0 0)) (q/rect-mode :radius) (q/with-translation [375 125] (q/stroke 0) (q/rect 0 0 100 70) (q/stroke 255 0 0) (q/point 0 0)) (q/rect-mode :corner) (q/with-translation [125 375] (q/stroke 0) (q/rect 0 0 100 70) (q/stroke 255 0 0) (q/point 0 0)) (q/rect-mode :corners) (q/with-translation [375 375] (q/stroke 0) (q/rect -50 -35 50 35) (q/stroke 255 0 0) (q/point -50 -35) (q/point 50 35)))",
+  "((q/stroke-weight 5) (comment \"use :center mode\") (q/rect-mode :center) (q/with-translation [125 125] (q/stroke 0) (q/rect 0 0 100 70) (q/stroke 255 0 0) (q/point 0 0)) (comment \"use :radius mode\") (q/rect-mode :radius) (q/with-translation [375 125] (q/stroke 0) (q/rect 0 0 100 70) (q/stroke 255 0 0) (q/point 0 0)) (comment \"use :corner mode\") (q/rect-mode :corner) (q/with-translation [125 375] (q/stroke 0) (q/rect 0 0 100 70) (q/stroke 255 0 0) (q/point 0 0)) (comment \"use :corners mode\") (q/rect-mode :corners) (q/with-translation [375 375] (q/stroke 0) (q/rect -50 -35 50 35) (q/stroke 255 0 0) (q/point -50 -35) (q/point 50 35)))",
   :setup "()",
   :target :cljs}
  {:fns ["smooth" "no-smooth"],
   :ns "quil.snippets.shape.attributes",
   :name "smooth-no-smooth",
   :opts {:renderer :p2d, :settings nil},
-  :draw "((q/with-translation [125 125] (q/ellipse 0 0 200 200)))",
+  :draw
+  "((comment \"that's a bad example. smooth is odd\") (q/with-translation [125 125] (q/ellipse 0 0 200 200)))",
   :setup "()",
   :target :cljs}
  {:fns ["ellipse-mode"],
@@ -1351,7 +1304,7 @@
   :name "ellipse-mode",
   :opts {:settings nil},
   :draw
-  "((q/stroke-weight 5) (q/ellipse-mode :center) (q/with-translation [125 125] (q/ellipse 0 0 100 70) (q/point 0 0)) (q/ellipse-mode :radius) (q/with-translation [375 125] (q/ellipse 0 0 100 70) (q/point 0 0)) (q/ellipse-mode :corner) (q/with-translation [125 375] (q/ellipse 0 0 100 70) (q/point 0 0)) (q/ellipse-mode :corners) (q/with-translation [375 375] (q/ellipse -50 -35 50 35) (q/point -50 -35) (q/point 50 35)))",
+  "((q/stroke-weight 5) (comment \"use :center mode\") (q/ellipse-mode :center) (q/with-translation [125 125] (q/ellipse 0 0 100 70) (q/point 0 0)) (comment \"use :radius mode\") (q/ellipse-mode :radius) (q/with-translation [375 125] (q/ellipse 0 0 100 70) (q/point 0 0)) (comment \"use :corner mode\") (q/ellipse-mode :corner) (q/with-translation [125 375] (q/ellipse 0 0 100 70) (q/point 0 0)) (comment \"use :corners mode\") (q/ellipse-mode :corners) (q/with-translation [375 375] (q/ellipse -50 -35 50 35) (q/point -50 -35) (q/point 50 35)))",
   :setup "()",
   :target :cljs}
  {:fns ["text-font"],
@@ -1359,32 +1312,25 @@
   :name "text-font",
   :opts {:settings nil},
   :draw
-  "((q/background 255) (q/fill 0) (let [font (q/create-font \"serif\" 20)] (q/text-font font) (q/text \"(print :hello)\" 20 30) (q/text-font font 30) (q/text \"(print-bigger :hello)\" 20 100)))",
+  "((q/background 255) (q/fill 0) (let [font \"Courier New\"] (q/text-font font 20) (q/text \"(print :hello)\" 20 30) (q/text-font font 30) (q/text \"(print-bigger :hello)\" 20 100)))",
   :setup "()",
   :target :cljs}
  {:fns ["text"],
   :ns "quil.snippets.typography.loading-and-displaying",
-  :name "text",
-  :opts {:renderer :p3d, :settings nil},
-  :draw
-  "((q/background 255) (q/fill 0) (q/camera 50 50 50 0 0 0 0 0 -1) (comment \"draw x/y/z axis\") (q/line 0 0 0 0 0 20) (q/line 0 0 0 0 20 0) (q/line 0 0 0 20 0 0) (comment \"draw text '2D'\") (q/text \"2D\" 0 15) (q/rotate-x (- q/HALF-PI)) (comment \"draw text '3D'\") (q/text \"3D\" 0 -5 0) (comment \"draw text 'box'\") (q/rotate-y q/HALF-PI) (q/rect-mode :corners) (q/text \"box\" -30 0 30 -15))",
-  :setup "()",
-  :target :cljs}
- {:fns ["create-font"],
-  :ns "quil.snippets.typography.loading-and-displaying",
-  :name "create-font",
+  :name "text-2d",
   :opts {:settings nil},
   :draw
-  "((q/background 255) (q/fill 0) (comment \"create font by name and size\") (q/text-font (q/create-font \"Courier New\" 30)) (q/text \"(print :hello)\" 20 50) (comment \"create font by name and size and using smooth\") (q/text-font (q/create-font \"Georgia\" 30 true)) (q/text \"(print :hello)\" 20 100))",
+  "((q/background 255) (q/fill 0) (comment \"draw text\") (q/text \"word\" 10 30) (comment \"draw text in a 'box'\") (q/text \"a long sentence wrapping inside a box\" 60 20 120 60))",
   :setup "()",
   :target :cljs}
- {:fns ["available-fonts"],
+ {:fns ["background-image"],
   :ns "quil.snippets.typography.loading-and-displaying",
-  :name "available-fonts",
+  :name "load-font",
   :opts {:settings nil},
   :draw
-  "((q/background 255) (q/fill 0) (q/text-size 10) (doseq [[col fonts] (->> (q/available-fonts) (partition-all 50) (map-indexed vector)) [row font] (map-indexed vector fonts)] (q/text font (+ 20 (* col 100)) (+ 20 (* row 10)))))",
-  :setup "()",
+  "((q/background 255) (q/fill 0) (let [font (q/state :font)] (q/text-font font) (q/text \"CoMiC SaNs HeRe\" 20 100)))",
+  :setup
+  "(let [_ (comment \"create url to load font\") url \"https://www.fontsquirrel.com/fonts/download/roboto\"] (q/set-state! :font (q/load-font url)))",
   :target :cljs}
  {:fns ["text-descent"],
   :ns "quil.snippets.typography.metrics",
@@ -1415,7 +1361,7 @@
   :name "text-font",
   :opts {:settings nil},
   :draw
-  "((q/background 255) (q/fill 0) (let [font (q/create-font \"Courier New\" 20)] (q/text-font font) (q/text \"(print :hello)\" 20 30) (q/text-font font 30) (q/text \"(print-bigger :hello)\" 20 100)))",
+  "((q/background 255) (q/fill 0) (let [font (q/create-font \"Courier New\" 20)] (q/text-font font 20) (q/text \"(print :hello)\" 20 30) (q/text-font font 30) (q/text \"(print-bigger :hello)\" 20 100)))",
   :setup "()",
   :target :clj}
  {:fns ["text-char"],
@@ -1428,19 +1374,28 @@
   :target :clj}
  {:fns ["text"],
   :ns "quil.snippets.typography.loading-and-displaying",
-  :name "text",
+  :name "text-3d",
   :opts {:renderer :p3d, :settings nil},
   :draw
   "((q/background 255) (q/fill 0) (q/camera 50 50 50 0 0 0 0 0 -1) (comment \"draw x/y/z axis\") (q/line 0 0 0 0 0 20) (q/line 0 0 0 0 20 0) (q/line 0 0 0 20 0 0) (comment \"draw text '2D'\") (q/text \"2D\" 0 15) (q/rotate-x (- q/HALF-PI)) (comment \"draw text '3D'\") (q/text \"3D\" 0 -5 0) (comment \"draw text 'box'\") (q/rotate-y q/HALF-PI) (q/rect-mode :corners) (q/text \"box\" -30 0 30 -15))",
   :setup "()",
   :target :clj}
- {:fns ["load-font"],
+ {:fns ["text"],
+  :ns "quil.snippets.typography.loading-and-displaying",
+  :name "text-2d",
+  :opts {:settings nil},
+  :draw
+  "((q/background 255) (q/fill 0) (comment \"draw text\") (q/text \"word\" 10 30) (comment \"draw text in a 'box'\") (q/text \"a long sentence wrapping inside a box\" 60 20 120 60))",
+  :setup "()",
+  :target :clj}
+ {:fns ["background-image"],
   :ns "quil.snippets.typography.loading-and-displaying",
   :name "load-font",
   :opts {:settings nil},
   :draw
-  "((q/background 255) (q/fill 0) (->> (clojure.java.io/resource \"ComicSansMS-48.vlw\") (.getPath) (q/load-font) (q/text-font)) (q/text \"CoMiC SaNs HeRe\" 20 100))",
-  :setup "()",
+  "((q/background 255) (q/fill 0) (let [font (q/state :font)] (q/text-font font) (q/text \"CoMiC SaNs HeRe\" 20 100)))",
+  :setup
+  "(let [_ (comment \"create url to load font\") url (.getPath (clojure.java.io/resource \"ComicSansMS-48.vlw\"))] (q/set-state! :font (q/load-font url)))",
   :target :clj}
  {:fns ["font-available?"],
   :ns "quil.snippets.typography.loading-and-displaying",
@@ -1455,7 +1410,7 @@
   :name "create-font",
   :opts {:settings nil},
   :draw
-  "((q/background 255) (q/fill 0) (comment \"create font by name and size\") (q/text-font (q/create-font \"Courier New\" 30)) (q/text \"(print :hello)\" 20 50) (comment \"create font by name and size and using smooth\") (q/text-font (q/create-font \"Georgia\" 30 true)) (q/text \"(print :hello)\" 20 100) (comment \"create font using with all parameters\") (q/text-font (q/create-font \"Georgia\" 30 false (char-array \"what is it for?\"))) (q/text \"(print :hello)\" 20 150))",
+  "((q/background 255) (q/fill 0) (comment \"create font by name and size\") (q/text-font (q/create-font \"Courier New\" 30)) (q/text \"(print :hello)\" 20 50) (comment \"create font by name and size and using smooth\") (q/text-font (q/create-font \"Georgia\" 30 true)) (q/text \"(print :hello)\" 20 100) (comment \"create font with all parameters\") (q/text-font (q/create-font \"Georgia\" 30 false (char-array \"what is it for?\"))) (q/text \"(print :hello)\" 20 150))",
   :setup "()",
   :target :clj}
  {:fns ["available-fonts"],
@@ -1503,7 +1458,7 @@
   :name "text-align",
   :opts {:settings nil},
   :draw
-  "((q/fill 0) (q/stroke 255 0 0) (q/stroke-weight 5) (let [h-align [:left :center :right] v-align [:top :bottom :center :baseline]] (comment \"text-align with single argument\") (doseq [ind (range (count h-align)) :let [x 50 y (+ 20 (* ind 50))]] (q/text-align (h-align ind)) (q/text (name (h-align ind)) x y) (q/point x y)) (comment \"text-align with multiple arguments\") (doseq [ind-h (range (count h-align)) ind-v (range (count v-align)) :let [x (+ 70 (* ind-v 100)) y (+ 250 (* ind-h 50)) h-al (h-align ind-h) v-al (v-align ind-v) txt (str (name h-al) \"+\" (name v-al))]] (q/text-align h-al v-al) (q/text txt x y) (q/point x y))))",
+  "((q/fill 0) (let [h-align [:left :center :right] v-align [:top :bottom :center :baseline]] (comment \"text-align with single argument\") (doseq [ind (range (count h-align)) :let [x 50 y (+ 20 (* ind 50))]] (q/text-align (h-align ind)) (q/text (name (h-align ind)) x y) (q/push-style) (q/stroke 255 0 0) (q/stroke-weight 5) (q/point x y) (q/pop-style)) (comment \"text-align with multiple arguments\") (doseq [ind-h (range (count h-align)) ind-v (range (count v-align)) :let [x (+ 70 (* ind-v 100)) y (+ 250 (* ind-h 50)) h-al (h-align ind-h) v-al (v-align ind-v) txt (str (name h-al) \"+\" (name v-al))]] (q/text-align h-al v-al) (q/text txt x y) (q/push-style) (q/stroke 255 0 0) (q/stroke-weight 5) (q/point x y) (q/pop-style))))",
   :setup "()",
   :target :clj}
  {:fns ["with-translation"],
@@ -1551,7 +1506,7 @@
   :name "vertex",
   :opts {:renderer :p3d, :settings nil},
   :draw
-  "((q/camera 100 400 200 100 0 0 0 0 -1) (q/line 0 0 0 0 0 100) (q/line 0 0 0 0 100 0) (q/line 0 0 0 100 0 0) (let [txtr (q/create-graphics 100 100)] (q/with-graphics txtr (q/background 255) (q/fill 255 0 0) (q/rect 0 60 100 40) (q/fill 0 150 0) (q/rect 0 0 100 60)) (q/begin-shape) (q/vertex 0 0) (q/vertex 100 0) (q/vertex 100 100) (q/vertex 0 100) (q/end-shape :close) (q/begin-shape) (q/vertex 0 0 0) (q/vertex 100 0 0) (q/vertex 100 0 100) (q/vertex 0 0 100) (q/end-shape :close) (q/begin-shape) (q/texture txtr) (q/vertex 100 0 0 0) (q/vertex 200 0 100 0) (q/vertex 200 100 100 100) (q/vertex 100 100 0 100) (q/end-shape :close) (q/begin-shape) (q/texture txtr) (q/vertex 100 0 0 0 0) (q/vertex 200 0 0 100 0) (q/vertex 200 0 100 100 100) (q/vertex 100 0 100 0 100) (q/end-shape :close)))",
+  "((q/camera 100 400 200 100 0 0 0 0 -1) (q/line 0 0 0 0 0 150) (q/line 0 0 0 0 150 0) (q/line 0 0 0 150 0 0) (let [txtr (q/create-graphics 100 100)] (q/with-graphics txtr (q/background 255) (comment \"draw belarusian flag, kinda\") (q/fill 255 0 0) (q/rect 0 60 100 40) (q/fill 0 150 0) (q/rect 0 0 100 60)) (comment \"draw blue rect\") (q/fill 0 0 127) (q/begin-shape) (q/vertex 0 0) (q/vertex 100 0) (q/vertex 100 100) (q/vertex 0 100) (q/end-shape :close) (comment \"draw another blue rect\") (q/begin-shape) (q/vertex 0 0 0) (q/vertex 100 0 0) (q/vertex 100 0 100) (q/vertex 0 0 100) (q/end-shape :close) (comment \"draw rect using our custom texture\") (q/begin-shape) (q/texture txtr) (q/vertex 100 0 0 0) (q/vertex 200 0 100 0) (q/vertex 200 100 100 100) (q/vertex 100 100 0 100) (q/end-shape :close) (comment \"draw another rect using our custom texture\") (q/begin-shape) (q/texture txtr) (q/vertex 100 0 0 0 0) (q/vertex 200 0 0 100 0) (q/vertex 200 0 100 100 100) (q/vertex 100 0 100 0 100) (q/end-shape :close)))",
   :setup "()",
   :target :clj}
  {:fns ["texture-wrap"],
@@ -1575,7 +1530,7 @@
   :name "texture",
   :opts {:renderer :p2d, :settings nil},
   :draw
-  "((let [gr (q/create-graphics 100 100)] (q/with-graphics gr (q/background 255) (q/fill 255 0 0) (q/rect 0 60 100 40) (q/fill 0 150 0) (q/rect 0 0 100 60)) (q/image gr 0 0) (q/with-translation [250 250] (q/begin-shape) (q/texture gr) (q/vertex 50 100 75 100) (q/vertex 100 50 100 75) (q/vertex 100 -50 100 25) (q/vertex 50 -100 75 0) (q/vertex -50 -100 25 0) (q/vertex -100 -50 0 25) (q/vertex -100 50 0 75) (q/vertex -50 100 25 100) (q/end-shape :close))))",
+  "((let [gr (q/create-graphics 100 100)] (comment \"draw something on graphics that will be texture\") (q/with-graphics gr (q/background 255) (q/fill 255 0 0) (q/rect 0 60 100 40) (q/fill 0 150 0) (q/rect 0 0 100 60)) (comment \"draw graphics to see what we got\") (q/image gr 0 0) (comment \"draw custom shape using texture we created above\") (q/with-translation [250 250] (q/begin-shape) (q/texture gr) (q/vertex 50 100 75 100) (q/vertex 100 50 100 75) (q/vertex 100 -50 100 25) (q/vertex 50 -100 75 0) (q/vertex -50 -100 25 0) (q/vertex -100 -50 0 25) (q/vertex -100 50 0 75) (q/vertex -50 100 25 100) (q/end-shape :close))))",
   :setup "()",
   :target :clj}
  {:fns ["quadratic-vertex"],
@@ -1583,7 +1538,7 @@
   :name "quadratic-vertex",
   :opts {:renderer :p3d, :settings nil},
   :draw
-  "((q/camera 50 200 50 50 0 0 0 0 -1) (q/line 0 0 0 0 0 100) (q/line 0 0 0 0 100 0) (q/line 0 0 0 100 0 0) (q/begin-shape) (q/vertex 0 0) (q/quadratic-vertex 30 50 10 100) (q/quadratic-vertex 50 -50 90 100) (q/quadratic-vertex 80 50 100 0) (q/end-shape :close) (q/begin-shape) (q/vertex 0 0 0) (q/quadratic-vertex 30 0 50 10 0 100) (q/quadratic-vertex 50 0 -50 90 0 100) (q/quadratic-vertex 80 0 50 100 0 0) (q/end-shape :close))",
+  "((comment \"setup camera and draw axes\") (q/camera 50 200 50 50 0 0 0 0 -1) (q/line 0 0 0 0 0 100) (q/line 0 0 0 0 100 0) (q/line 0 0 0 100 0 0) (comment \"draw first shape\") (q/begin-shape) (q/vertex 0 0) (q/quadratic-vertex 30 50 10 100) (q/quadratic-vertex 50 -50 90 100) (q/quadratic-vertex 80 50 100 0) (q/end-shape :close) (comment \"draw second shape\") (q/begin-shape) (q/vertex 0 0 0) (q/quadratic-vertex 30 0 50 10 0 100) (q/quadratic-vertex 50 0 -50 90 0 100) (q/quadratic-vertex 80 0 50 100 0 0) (q/end-shape :close))",
   :setup "()",
   :target :clj}
  {:fns ["curve-vertex"],
@@ -1591,7 +1546,7 @@
   :name "curve-vertex",
   :opts {:renderer :p3d, :settings nil},
   :draw
-  "((q/camera 50 200 50 50 0 0 0 0 1) (q/begin-shape) (q/curve-vertex 0 0) (q/curve-vertex 0 0) (q/curve-vertex 100 20) (q/curve-vertex 100 80) (q/curve-vertex 20 80) (q/curve-vertex 0 0) (q/curve-vertex 0 0) (q/end-shape :close) (q/begin-shape) (q/curve-vertex 0 0 0) (q/curve-vertex 0 0 0) (q/curve-vertex 100 0 20) (q/curve-vertex 100 0 80) (q/curve-vertex 20 0 80) (q/curve-vertex 0 0 0) (q/curve-vertex 0 0 0) (q/end-shape :close))",
+  "((q/camera 50 200 50 50 0 0 0 0 1) (comment \"draw first shape\") (q/begin-shape) (q/curve-vertex 0 0) (q/curve-vertex 0 0) (q/curve-vertex 100 20) (q/curve-vertex 100 80) (q/curve-vertex 20 80) (q/curve-vertex 0 0) (q/curve-vertex 0 0) (q/end-shape :close) (comment \"draw second shape\") (q/begin-shape) (q/curve-vertex 0 0 0) (q/curve-vertex 0 0 0) (q/curve-vertex 100 0 20) (q/curve-vertex 100 0 80) (q/curve-vertex 20 0 80) (q/curve-vertex 0 0 0) (q/curve-vertex 0 0 0) (q/end-shape :close))",
   :setup "()",
   :target :clj}
  {:fns ["bezier-vertex"],
@@ -1599,7 +1554,7 @@
   :name "bezier-vertex",
   :opts {:renderer :p3d, :settings nil},
   :draw
-  "((q/camera -400 250 -100 500 250 0 0 0 1) (q/begin-shape) (q/vertex 30 20) (q/bezier-vertex 480 0 480 475 30 475) (q/bezier-vertex 250 380 360 125 30 20) (q/end-shape :close) (q/begin-shape) (q/vertex 30 20 0) (q/bezier-vertex 480 0 20 480 475 30 30 475 40) (q/bezier-vertex 250 380 40 360 125 10 30 20 0) (q/end-shape :close))",
+  "((q/camera -400 250 -100 500 250 0 0 0 1) (comment \"draw first shape\") (q/begin-shape) (q/vertex 30 20) (q/bezier-vertex 480 0 480 475 30 475) (q/bezier-vertex 250 380 360 125 30 20) (q/end-shape :close) (comment \"draw second shape\") (q/begin-shape) (q/vertex 30 20 0) (q/bezier-vertex 480 0 20 480 475 30 30 475 40) (q/bezier-vertex 250 380 40 360 125 10 30 20 0) (q/end-shape :close))",
   :setup "()",
   :target :clj}
  {:fns ["begin-shape" "end-shape"],
@@ -1615,7 +1570,7 @@
   :name "begin-shape-end-shape",
   :opts {:renderer :p2d, :settings nil},
   :draw
-  "((q/stroke 255 0 0) (doseq [[ind begin-mode close-mode] [[0 nil nil] [1 nil :close] [2 :points] [3 :lines] [4 :triangles] [5 :triangle-fan] [6 :triangle-strip] [7 :quads] [8 :quad-strip]] :let [base-x (* 150 (mod ind 3)) base-y (* 150 (quot ind 3))]] (if begin-mode (q/begin-shape begin-mode) (q/begin-shape)) (q/vertex (+ base-x 50) (+ base-y 10)) (q/vertex (+ base-x 80) (+ base-y 30)) (q/vertex (+ base-x 80) (+ base-y 70)) (q/vertex (+ base-x 50) (+ base-y 90)) (q/vertex (+ base-x 20) (+ base-y 70)) (q/vertex (+ base-x 20) (+ base-y 30)) (if close-mode (q/end-shape close-mode) (q/end-shape))))",
+  "((q/stroke 255 0 0) (comment \"try all kinds of begin modes\") (doseq [[ind begin-mode close-mode] [[0 nil nil] [1 nil :close] [2 :points] [3 :lines] [4 :triangles] [5 :triangle-fan] [6 :triangle-strip] [7 :quads] [8 :quad-strip]] :let [base-x (* 150 (mod ind 3)) base-y (* 150 (quot ind 3))]] (if begin-mode (q/begin-shape begin-mode) (q/begin-shape)) (q/vertex (+ base-x 50) (+ base-y 10)) (q/vertex (+ base-x 80) (+ base-y 30)) (q/vertex (+ base-x 80) (+ base-y 70)) (q/vertex (+ base-x 50) (+ base-y 90)) (q/vertex (+ base-x 20) (+ base-y 70)) (q/vertex (+ base-x 20) (+ base-y 30)) (if close-mode (q/end-shape close-mode) (q/end-shape))))",
   :setup "()",
   :target :clj}
  {:fns ["begin-contour" "end-contour"],
@@ -1623,7 +1578,7 @@
   :name "begin-contour-end-contour",
   :opts {:renderer :p2d, :settings nil},
   :draw
-  "((q/stroke 255 0 0) (q/begin-shape) (q/vertex 250 20) (q/vertex 400 400) (q/vertex 50 400) (q/begin-contour) (q/vertex 200 200) (q/vertex 300 200) (q/vertex 250 380) (q/end-contour) (q/end-shape :close))",
+  "((q/stroke 255 0 0) (q/fill 0 127 0) (q/begin-shape) (comment \"outer shape\") (q/vertex 250 20) (q/vertex 400 400) (q/vertex 50 400) (comment \"inner shape\") (q/begin-contour) (q/vertex 200 200) (q/vertex 250 380) (q/vertex 300 200) (q/end-contour) (q/end-shape :close))",
   :setup "()",
   :target :clj}
  {:fns ["sphere-detail"],
@@ -1662,7 +1617,7 @@
   :name "rect",
   :opts {:settings nil},
   :draw
-  "((q/background 255) (q/fill 220 200 255) (q/rect 50 50 150 100) (q/rect 300 50 150 100 20) (q/rect 50 300 150 100 5 10 20 30))",
+  "((q/background 255) (q/fill 220 200 255) (comment \"normal rect\") (q/rect 50 50 150 100) (comment \"rect with rounded corners\") (q/rect 300 50 150 100 20) (comment \"rect with rounded corners where each corner is different\") (q/rect 50 300 150 100 5 10 20 30))",
   :setup "()",
   :target :clj}
  {:fns ["quad"],
@@ -1678,7 +1633,7 @@
   :name "point",
   :opts {:renderer :p3d, :settings nil},
   :draw
-  "((q/background 255) (q/stroke-weight 10) (q/stroke 255 0 0) (q/point 10 10) (q/stroke 0 0 255) (q/point 50 50 -200))",
+  "((q/background 255) (q/stroke-weight 10) (comment \"red ponit\") (q/stroke 255 0 0) (q/point 10 10) (comment \"blue point\") (q/stroke 0 0 255) (q/point 50 50 -200))",
   :setup "()",
   :target :clj}
  {:fns ["line"],
@@ -1686,7 +1641,7 @@
   :name "line",
   :opts {:renderer :p3d, :settings nil},
   :draw
-  "((q/background 255) (q/camera 250 250 250 0 0 0 0 0 -1) (q/stroke 255 0 0) (q/line [0 0] [100 100]) (q/stroke 0 255 0) (q/line 100 0 0 100) (q/stroke 0 0 255) (q/line 0 0 0 170 120 100) (q/line 170 120 100 50 -50 20) (q/line 50 -50 20 0 0 0))",
+  "((q/background 255) (q/camera 250 250 250 0 0 0 0 0 -1) (comment \"red line\") (q/stroke 255 0 0) (q/line [0 0] [100 100]) (comment \"green line\") (q/stroke 0 255 0) (q/line 100 0 0 100) (comment \"three blue lines\") (q/stroke 0 0 255) (q/line 0 0 0 170 120 100) (q/line 170 120 100 50 -50 20) (q/line 50 -50 20 0 0 0))",
   :setup "()",
   :target :clj}
  {:fns ["ellipse"],
@@ -1702,7 +1657,7 @@
   :name "arc",
   :opts {:settings nil},
   :draw
-  "((q/background 255) (q/stroke 0) (q/fill 220 200 255) (q/arc 50 100 200 170 0 q/QUARTER-PI) (doseq [[ind mode] [[0 :open] [1 :chord] [2 :pie]]] (q/arc (+ 50 (* ind 150)) 300 200 170 0 q/QUARTER-PI mode)))",
+  "((q/background 255) (q/stroke 0) (q/fill 220 200 255) (comment \"draw default arc\") (q/arc 50 100 200 170 0 q/QUARTER-PI) (comment \"draw different arc modes\") (doseq [[ind mode] [[0 :open] [1 :chord] [2 :pie]]] (q/arc (+ 50 (* ind 150)) 300 200 170 0 q/QUARTER-PI mode)))",
   :setup "()",
   :target :clj}
  {:fns ["shape-mode"],
@@ -1713,28 +1668,21 @@
   "((let [sh (q/load-shape \"https://upload.wikimedia.org/wikipedia/en/2/22/Heckert_GNU_white.svg\")] (q/stroke-weight 5) (q/stroke 255 0 0) (q/shape-mode :corner) (q/shape sh 20 20 200 200) (q/point 20 20) (q/shape-mode :corners) (q/shape sh 270 20 370 120) (q/point 270 20) (q/point 370 120) (q/shape-mode :center) (q/shape sh 100 350 150 150) (q/point 100 350)))",
   :setup "()",
   :target :clj}
- {:fns ["shape"],
+ {:fns ["shape" "load-shape"],
   :ns "quil.snippets.shape.loading-and-displaying",
   :name "shape",
-  :opts {:renderer :p2d, :settings nil},
+  :opts {:renderer :p3d, :settings nil},
   :draw
-  "((let [sh (q/load-shape \"https://upload.wikimedia.org/wikipedia/en/2/22/Heckert_GNU_white.svg\")] (q/shape sh) (q/shape sh 100 100) (q/shape sh 300 300 200 200)))",
-  :setup "()",
-  :target :clj}
- {:fns ["load-shape"],
-  :ns "quil.snippets.shape.loading-and-displaying",
-  :name "load-shape",
-  :opts {:renderer :p2d, :settings nil},
-  :draw
-  "((let [sh (q/load-shape \"https://upload.wikimedia.org/wikipedia/en/2/22/Heckert_GNU_white.svg\")] (q/shape sh 0 0 500 500)))",
-  :setup "()",
+  "((let [sh (q/state :shp)] (q/shape sh) (q/shape sh 100 100) (q/shape sh 300 300 200 200)))",
+  :setup
+  "(let [sh (q/load-shape \"https://upload.wikimedia.org/wikipedia/en/2/22/Heckert_GNU_white.svg\")] (q/set-state! :shp sh))",
   :target :clj}
  {:fns ["curve-tightness"],
   :ns "quil.snippets.shape.curves",
   :name "curve-tightness",
   :opts {:settings nil},
   :draw
-  "((q/no-fill) (doseq [[ind t] [[0 -5] [1 -1] [2 0] [3 1] [4 5]]] (q/curve-tightness t) (q/with-translation [100 (+ 50 (* ind 70))] (q/curve 0 0 0 0 50 30 100 -30) (q/curve 0 0 50 30 100 -30 150 0) (q/curve 50 30 100 -30 150 0 150 0))))",
+  "((q/no-fill) (comment \"try different tightnesses\") (doseq [[ind t] [[0 -5] [1 -1] [2 0] [3 1] [4 5]]] (q/curve-tightness t) (q/with-translation [100 (+ 50 (* ind 70))] (q/curve 0 0 0 0 50 30 100 -30) (q/curve 0 0 50 30 100 -30 150 0) (q/curve 50 30 100 -30 150 0 150 0))))",
   :setup "()",
   :target :clj}
  {:fns ["curve-tangent"],
@@ -1742,7 +1690,7 @@
   :name "curve-tangent",
   :opts {:settings nil},
   :draw
-  "((q/fill 0) (dotimes [i 5] (let [v (/ i 4) res (q/curve-tangent 0 5 7 0 v) txt (str \"(q/bezier-point 0 5 7 0 \" v \") = \" res)] (q/text txt 10 (+ 20 (* i 20))))))",
+  "((comment \"see https://p5js.org/reference/#/p5/curveTangent for better example\") (q/fill 0) (dotimes [i 5] (let [v (/ i 4) res (q/curve-tangent 0 5 7 0 v) txt (str \"(q/curve-tangent 0 5 7 0 \" v \") = \" res)] (q/text txt 10 (+ 20 (* i 20))))))",
   :setup "()",
   :target :clj}
  {:fns ["curve-point"],
@@ -1750,7 +1698,7 @@
   :name "curve-point",
   :opts {:settings nil},
   :draw
-  "((q/fill 0) (dotimes [i 5] (let [v (/ i 4) res (q/curve-point 0 5 7 0 v) txt (str \"(q/bezier-point 0 5 7 0 \" v \") = \" res)] (q/text txt 10 (+ 20 (* i 20))))))",
+  "((comment \"see https://p5js.org/reference/#/p5/curvePoint for better example\") (q/fill 0) (dotimes [i 5] (let [v (/ i 4) res (q/curve-point 0 5 7 0 v) txt (str \"(q/curve-point 0 5 7 0 \" v \") = \" res)] (q/text txt 10 (+ 20 (* i 20))))))",
   :setup "()",
   :target :clj}
  {:fns ["curve-detail"],
@@ -1774,7 +1722,7 @@
   :name "bezier-tangent",
   :opts {:settings nil},
   :draw
-  "((q/fill 0) (dotimes [i 5] (let [v (/ i 4) res (q/bezier-tangent 0 5 7 0 v) txt (str \"(q/bezier-point 0 5 7 0 \" v \") = \" res)] (q/text txt 10 (+ 20 (* i 20))))))",
+  "((comment \"see https://p5js.org/reference/#/p5/bezierTangent for better example\") (q/fill 0) (dotimes [i 5] (let [v (/ i 4) res (q/bezier-tangent 0 5 7 0 v) txt (str \"(q/bezier-tangent 0 5 7 0 \" v \") = \" res)] (q/text txt 10 (+ 20 (* i 20))))))",
   :setup "()",
   :target :clj}
  {:fns ["bezier-point"],
@@ -1782,7 +1730,7 @@
   :name "bezier-point",
   :opts {:settings nil},
   :draw
-  "((q/fill 0) (dotimes [i 5] (let [v (/ i 4) res (q/bezier-point 0 5 7 0 v) txt (str \"(q/bezier-point 0 5 7 0 \" v \") = \" res)] (q/text txt 10 (+ 20 (* i 20))))))",
+  "((comment \"see https://p5js.org/reference/#/p5/bezierPoint for better example\") (q/fill 0) (dotimes [i 5] (let [v (/ i 4) res (q/bezier-point 0 5 7 0 v) txt (str \"(q/bezier-point 0 5 7 0 \" v \") = \" res)] (q/text txt 10 (+ 20 (* i 20))))))",
   :setup "()",
   :target :clj}
  {:fns ["bezier-detail"],
@@ -1790,15 +1738,23 @@
   :name "bezier-detail",
   :opts {:renderer :p3d, :settings nil},
   :draw
-  "((q/camera 0 0 300 0 0 0 0 1 0) (q/no-fill) (q/bezier-detail 5) (q/bezier 0 0 50 100 100 -100 150 0) (q/bezier-detail 20) (q/bezier 0 0 -50 100 -100 -100 -150 0))",
+  "((q/camera 0 0 300 0 0 0 0 1 0) (q/no-fill) (q/bezier-detail 5) (q/bezier 0 0 0 0 100 0 0 100 0 100 0 0))",
   :setup "()",
   :target :clj}
- {:fns ["bezier"],
+ {:fns ["bezier-3d"],
   :ns "quil.snippets.shape.curves",
-  :name "bezier",
+  :name "bezier-3d",
   :opts {:renderer :p3d, :settings nil},
   :draw
-  "((q/camera 200 200 200 0 0 0 0 0 -1) (q/no-fill) (q/bezier 0 0 50 100 100 -100 150 0) (q/bezier 0 0 0 0 100 0 0 100 0 100 0 0))",
+  "((q/camera 200 200 200 0 0 0 0 0 -1) (q/no-fill) (q/bezier 0 0 0 0 100 0 0 100 0 100 0 0))",
+  :setup "()",
+  :target :clj}
+ {:fns ["bezier-2d"],
+  :ns "quil.snippets.shape.curves",
+  :name "bezier-2d",
+  :opts {:settings nil},
+  :draw
+  "((q/no-fill) (q/with-translation [100 100] (q/bezier 0 0 50 100 100 -100 150 0)))",
   :setup "()",
   :target :clj}
  {:fns ["stroke-weight"],
@@ -1814,7 +1770,7 @@
   :name "stroke-join",
   :opts {:settings nil},
   :draw
-  "((q/rect-mode :center) (q/stroke-weight 12) (q/stroke-join :miter) (q/rect 125 125 100 100) (q/stroke-join :bevel) (q/rect 375 125 100 100) (q/stroke-join :round) (q/rect 125 375 100 100))",
+  "((q/rect-mode :center) (q/stroke-weight 12) (comment \"use :miter join\") (q/stroke-join :miter) (q/rect 125 125 100 100) (comment \"use :bevel join\") (q/stroke-join :bevel) (q/rect 375 125 100 100) (comment \"use :round join\") (q/stroke-join :round) (q/rect 125 375 100 100))",
   :setup "()",
   :target :clj}
  {:fns ["stroke-cap"],
@@ -1822,7 +1778,7 @@
   :name "stroke-cap",
   :opts {:settings nil},
   :draw
-  "((q/stroke-weight 12) (q/stroke-cap :square) (q/line 230 200 270 200) (q/stroke-cap :project) (q/line 230 250 270 250) (q/stroke-cap :round) (q/line 230 300 270 300))",
+  "((q/stroke-weight 12) (comment \"use :square cap\") (q/stroke-cap :square) (q/line 230 200 270 200) (comment \"use :project cap\") (q/stroke-cap :project) (q/line 230 250 270 250) (comment \"use :round cap\") (q/stroke-cap :round) (q/line 230 300 270 300))",
   :setup "()",
   :target :clj}
  {:fns ["rect-mode"],
@@ -1830,14 +1786,15 @@
   :name "rect-mode",
   :opts {:settings nil},
   :draw
-  "((q/stroke-weight 5) (q/rect-mode :center) (q/with-translation [125 125] (q/stroke 0) (q/rect 0 0 100 70) (q/stroke 255 0 0) (q/point 0 0)) (q/rect-mode :radius) (q/with-translation [375 125] (q/stroke 0) (q/rect 0 0 100 70) (q/stroke 255 0 0) (q/point 0 0)) (q/rect-mode :corner) (q/with-translation [125 375] (q/stroke 0) (q/rect 0 0 100 70) (q/stroke 255 0 0) (q/point 0 0)) (q/rect-mode :corners) (q/with-translation [375 375] (q/stroke 0) (q/rect -50 -35 50 35) (q/stroke 255 0 0) (q/point -50 -35) (q/point 50 35)))",
+  "((q/stroke-weight 5) (comment \"use :center mode\") (q/rect-mode :center) (q/with-translation [125 125] (q/stroke 0) (q/rect 0 0 100 70) (q/stroke 255 0 0) (q/point 0 0)) (comment \"use :radius mode\") (q/rect-mode :radius) (q/with-translation [375 125] (q/stroke 0) (q/rect 0 0 100 70) (q/stroke 255 0 0) (q/point 0 0)) (comment \"use :corner mode\") (q/rect-mode :corner) (q/with-translation [125 375] (q/stroke 0) (q/rect 0 0 100 70) (q/stroke 255 0 0) (q/point 0 0)) (comment \"use :corners mode\") (q/rect-mode :corners) (q/with-translation [375 375] (q/stroke 0) (q/rect -50 -35 50 35) (q/stroke 255 0 0) (q/point -50 -35) (q/point 50 35)))",
   :setup "()",
   :target :clj}
  {:fns ["smooth" "no-smooth"],
   :ns "quil.snippets.shape.attributes",
   :name "smooth-no-smooth",
   :opts {:renderer :p2d, :settings nil},
-  :draw "((q/with-translation [125 125] (q/ellipse 0 0 200 200)))",
+  :draw
+  "((comment \"that's a bad example. smooth is odd\") (q/with-translation [125 125] (q/ellipse 0 0 200 200)))",
   :setup "()",
   :target :clj}
  {:fns ["ellipse-mode"],
@@ -1845,7 +1802,7 @@
   :name "ellipse-mode",
   :opts {:settings nil},
   :draw
-  "((q/stroke-weight 5) (q/ellipse-mode :center) (q/with-translation [125 125] (q/ellipse 0 0 100 70) (q/point 0 0)) (q/ellipse-mode :radius) (q/with-translation [375 125] (q/ellipse 0 0 100 70) (q/point 0 0)) (q/ellipse-mode :corner) (q/with-translation [125 375] (q/ellipse 0 0 100 70) (q/point 0 0)) (q/ellipse-mode :corners) (q/with-translation [375 375] (q/ellipse -50 -35 50 35) (q/point -50 -35) (q/point 50 35)))",
+  "((q/stroke-weight 5) (comment \"use :center mode\") (q/ellipse-mode :center) (q/with-translation [125 125] (q/ellipse 0 0 100 70) (q/point 0 0)) (comment \"use :radius mode\") (q/ellipse-mode :radius) (q/with-translation [375 125] (q/ellipse 0 0 100 70) (q/point 0 0)) (comment \"use :corner mode\") (q/ellipse-mode :corner) (q/with-translation [125 375] (q/ellipse 0 0 100 70) (q/point 0 0)) (comment \"use :corners mode\") (q/ellipse-mode :corners) (q/with-translation [375 375] (q/ellipse -50 -35 50 35) (q/point -50 -35) (q/point 50 35)))",
   :setup "()",
   :target :clj}
  {:fns ["tan"],
@@ -2109,7 +2066,7 @@
   :name "specular",
   :opts {:renderer :p3d, :settings nil},
   :draw
-  "((q/background 0) (q/camera 150 150 150 0 25 0 0 0 -1) (q/no-stroke) (q/fill 0 51 102) (q/light-specular 255 255 255) (q/directional-light 204 204 204 -1 -1 -1) (q/specular 255) (q/sphere 50) (q/translate 0 100 0) (q/specular 204 102 0) (q/sphere 40))",
+  "((q/fill 255) (q/background 0) (q/camera 150 150 150 0 25 0 0 0 -1) (q/ambient-light 60 60 60) (q/no-stroke) (q/fill 0 51 102) (q/light-specular 255 255 255) (q/directional-light 255 255 255 0 0 -1) (q/specular 255) (q/sphere 50) (q/translate 0 100 0) (q/specular 204 0 0) (q/sphere 40))",
   :setup "()",
   :target :clj}
  {:fns ["shininess"],
@@ -2117,7 +2074,7 @@
   :name "shininess",
   :opts {:renderer :p3d, :settings nil},
   :draw
-  "((q/background 0) (q/camera 150 150 150 0 25 0 0 0 -1) (q/fill 127 0 255) (q/no-stroke) (q/light-specular 204 204 204) (q/directional-light 102 102 102 -1 -1 -1) (q/specular 255 255 255) (q/shininess 2) (q/sphere 50) (q/translate 0 100 0) (q/shininess 10) (q/sphere 40))",
+  "((q/background 0) (q/camera 150 150 150 0 25 0 0 0 -1) (q/fill 127 0 255) (q/no-stroke) (q/light-specular 204 204 204) (q/directional-light 102 102 102 -1 -1 -1) (q/specular 255 255 255) (comment \"draw two spheres with different shininess\") (q/shininess 2) (q/sphere 50) (q/translate 0 100 0) (q/shininess 10) (q/sphere 40))",
   :setup "()",
   :target :clj}
  {:fns ["emissive"],
@@ -2133,7 +2090,7 @@
   :name "ambient",
   :opts {:renderer :p3d, :settings nil},
   :draw
-  "((q/background 0) (q/camera 150 150 150 0 0 0 0 0 -1) (q/ambient-light 255 127 127) (q/ambient 255 127 0) (q/box 100) (q/translate 0 100 0) (q/ambient 127) (q/sphere 40))",
+  "((q/background 0) (q/camera 150 150 150 0 0 0 0 0 -1) (comment \"set light to kinda pink\") (q/ambient-light 255 127 127) (comment \"first box has full reflectance\") (q/ambient 255) (q/translate 0 -50 0) (q/box 50) (comment \"second box has abmient material with blue-only component\") (q/translate 0 75 0) (q/ambient 0 0 255) (q/box 50) (comment \"third box has gray ambient material\") (q/translate 0 75 0) (q/ambient 127) (q/box 50))",
   :setup "()",
   :target :clj}
  {:fns ["spot-light"],
@@ -2141,7 +2098,7 @@
   :name "spot-light",
   :opts {:renderer :p3d, :settings nil},
   :draw
-  "((q/background 0) (q/camera 100 100 100 0 0 0 0 0 -1) (q/spot-light 255 0 0 50 0 50 -1 0 -1 q/PI 1) (q/spot-light [0 0 255] [0 100 100] [0 -1 -1] q/PI 1) (q/box 50))",
+  "((q/background 0) (q/camera 100 100 100 0 0 0 0 0 -1) (comment \"use two different ways to call spot-light\") (comment \"one light is red and another is blue\") (q/spot-light 255 0 0 50 0 50 -1 0 -1 q/PI 1) (q/spot-light [0 0 255] [0 100 100] [0 -1 -1] q/PI 1) (q/box 50))",
   :setup "()",
   :target :clj}
  {:fns ["point-light"],
@@ -2149,15 +2106,7 @@
   :name "point-light",
   :opts {:renderer :p3d, :settings nil},
   :draw
-  "((q/background 0) (q/camera 100 100 100 0 0 0 0 0 -1) (q/point-light 255 150 150 100 100 100) (q/box 50))",
-  :setup "()",
-  :target :clj}
- {:fns ["normal"],
-  :ns "quil.snippets.lights-camera.lights",
-  :name "normal",
-  :opts {:renderer :p3d, :settings nil},
-  :draw
-  "((q/background 0) (q/camera 100 100 100 40 40 0 0 0 -1) (q/point-light 150 250 150 10 30 50) (q/begin-shape) (q/normal 0 0 1) (doseq [v [[20 20 -10] [80 20 10] [80 80 -10] [20 80 10]]] (apply q/vertex v)) (q/end-shape :close))",
+  "((q/background 0) (q/camera 100 100 100 0 0 0 0 0 -1) (comment \"set light from the same point as camera [100, 100, 100]\") (q/point-light 255 150 150 100 100 100) (q/box 50))",
   :setup "()",
   :target :clj}
  {:fns ["no-lights"],
@@ -2165,7 +2114,7 @@
   :name "no-lights",
   :opts {:renderer :p3d, :settings nil},
   :draw
-  "((q/background 0) (q/camera 100 100 100 0 0 0 0 0 -1) (q/directional-light 255 150 150 -1 -0.76 -0.5) (q/box 50) (q/no-lights) (q/translate 0 50 0) (q/sphere 20))",
+  "((q/background 0) (q/camera 100 100 100 0 0 0 0 0 -1) (comment \"draw box with lights\") (q/directional-light 255 150 150 -1 -0.76 -0.5) (q/box 50) (comment \"draw sphere without lights\") (q/no-lights) (q/translate 0 50 0) (q/sphere 20))",
   :setup "()",
   :target :clj}
  {:fns ["lights"],
@@ -2197,7 +2146,7 @@
   :name "directional-light",
   :opts {:renderer :p3d, :settings nil},
   :draw
-  "((q/background 0) (q/camera 100 100 100 0 0 0 0 0 -1) (q/directional-light 255 150 150 -1 -0.76 -0.5) (q/box 50))",
+  "((q/background 0) (q/camera 100 100 100 0 0 0 0 0 -1) (comment \"use red-ish color with direction [-1, -0.76, -0.5]\") (q/directional-light 255 150 150 -1 -0.76 -0.5) (q/box 50))",
   :setup "()",
   :target :clj}
  {:fns ["ambient-light"],
@@ -2206,22 +2155,6 @@
   :opts {:renderer :p3d, :settings nil},
   :draw
   "((q/background 0) (q/camera 100 100 100 0 0 0 0 0 1) (q/ambient-light 200 190 230) (q/sphere 50))",
-  :setup "()",
-  :target :clj}
- {:fns ["screen-x" "screen-y" "screen-z"],
-  :ns "quil.snippets.lights-camera.coordinates",
-  :name "screen-x-y-z",
-  :opts {:renderer :p2d, :settings nil},
-  :draw
-  "((let [gr3d (q/create-graphics 240 240 :p3d) gr-text (q/create-graphics 240 240 :java2d)] (q/with-graphics gr3d (q/background 255) (q/camera 13 25 50 0 0 0 0 0 -1) (q/stroke-weight 2) (q/stroke 255 0 0) (q/line 0 0 0 20 0 0) (q/stroke 0 255 0) (q/line 0 0 0 0 20 0) (q/stroke 0 0 255) (q/line 0 0 0 0 0 20) (q/stroke 255 0 0) (q/stroke-weight 7) (q/point 0 0 0) (q/point 10 5 7) (let [x1 (q/screen-x 0 0) x2 (q/screen-x 10 5 7) y1 (q/screen-y 0 0) y2 (q/screen-y 10 5 7) z1 (q/model-z 0 0 0) z2 (q/model-z 10 5 7)] (q/with-graphics gr-text (q/background 255) (q/fill 0) (doseq [[ind capt val] [[1 \"(q/screen-x 0 0)\" x1] [2 \"(q/screen-x 10 5 6)\" x2] [3 \"(q/screen-y 0 0)\" y1] [4 \"(q/screen-y 10 5 6)\" y2] [5 \"(q/screen-z 0 0 0)\" x1] [6 \"(q/screen-z 10 5 6)\" z2]]] (q/text (str capt \" is \" val) 20 (* ind 20)))))) (q/image gr3d 0 0) (q/image gr-text 250 0)))",
-  :setup "()",
-  :target :clj}
- {:fns ["model-x" "model-y" "model-z"],
-  :ns "quil.snippets.lights-camera.coordinates",
-  :name "model-x-y-z",
-  :opts {:renderer :p2d, :settings nil},
-  :draw
-  "((let [gr3d (q/create-graphics 240 240 :p3d) gr-text (q/create-graphics 240 240 :java2d)] (q/with-graphics gr3d (q/background 255) (q/camera 50 25 13 0 0 0 0 0 -1) (q/stroke-weight 2) (q/stroke 255 0 0) (q/line 0 0 0 20 0 0) (q/stroke 0 255 0) (q/line 0 0 0 0 20 0) (q/stroke 0 0 255) (q/line 0 0 0 0 0 20) (q/stroke 255 0 0) (q/stroke-weight 5) (q/translate 10 20 5) (q/point 0 0 0) (let [x (q/model-x 0 0 0) y (q/model-y 0 0 0) z (q/model-z 0 0 0)] (q/with-graphics gr-text (q/background 255) (q/fill 0) (doseq [[ind capt val] [[1 \"(q/model-x 0 0 0)\" x] [2 \"(q/model-y 0 0 0)\" y] [3 \"(q/model-z 0 0 0)\" z]]] (q/text (str capt \" is \" val) 20 (* ind 20)))))) (q/image gr3d 0 0) (q/image gr-text 250 0)))",
   :setup "()",
   :target :clj}
  {:fns ["print-projection"],
@@ -2238,28 +2171,20 @@
   :draw "((q/print-camera))",
   :setup "()",
   :target :clj}
- {:fns ["perspective"],
+ {:fns ["ortho" "perspective"],
   :ns "quil.snippets.lights-camera.camera",
-  :name "perspective",
-  :opts {:renderer :p2d, :settings nil},
+  :name "ortho-perspective",
+  :opts {:renderer :p3d, :settings nil},
   :draw
-  "((let [perspective-params [[] [(/ q/PI 2) 0.5 50 300]] pos [[0 0] [250 0] [127 250]]] (dotimes [ind (count perspective-params)] (let [gr (q/create-graphics 240 240 :p3d)] (q/with-graphics gr (q/background 255) (q/camera 100 100 100 0 0 0 0 0 -1) (apply q/perspective (nth perspective-params ind)) (q/fill 127) (q/box 100)) (apply q/image gr (nth pos ind))))))",
-  :setup "()",
-  :target :clj}
- {:fns ["ortho"],
-  :ns "quil.snippets.lights-camera.camera",
-  :name "ortho",
-  :opts {:renderer :p2d, :settings nil},
-  :draw
-  "((let [ortho-params [[] [0 300 0 300] [0 300 0 300 0 170]] pos [[0 0] [250 0] [127 250]]] (dotimes [ind (count ortho-params)] (let [gr (q/create-graphics 240 240 :p3d)] (q/with-graphics gr (q/background 255) (q/camera 100 100 100 0 0 0 0 0 -1) (apply q/ortho (nth ortho-params ind)) (q/fill 127) (q/box 100)) (apply q/image gr (nth pos ind))))))",
-  :setup "()",
+  "((q/background 240) (comment \"flip between ortho and perspective camera every frame\") (comment \"enable ortho camera\") (comment \"in ortho all figures will look the same regardless distance\") (comment \"in perspective (default) all figures will look smaller the farther they are\") (if (even? (q/frame-count)) (q/ortho) (q/perspective)) (comment \"set camera to look from [300, 0, 300] at point [100, 0, 0]\") (q/camera 300 0 300 100 0 0 0 0 -1) (q/fill 0 127 127) (comment \"draw 3 boxes with x coordinates 0, 100 and 200\") (doseq [x [0 100 200]] (q/with-translation [x 0 0] (q/box 50))))",
+  :setup "(q/frame-rate 1)",
   :target :clj}
  {:fns ["frustum"],
   :ns "quil.snippets.lights-camera.camera",
   :name "frustum",
   :opts {:renderer :p3d, :settings nil},
   :draw
-  "((q/background 255) (q/camera 200 200 200 0 0 0 0 0 -1) (q/frustum -100 100 -100 100 200 330) (q/stroke-weight 2) (q/stroke 0) (q/fill 127) (q/box 100) (q/stroke 255 0 0) (q/line 0 0 0 100 0 0) (q/stroke 0 255 0) (q/line 0 0 0 0 100 0) (q/stroke 0 0 255) (q/line 0 0 0 0 0 100))",
+  "((q/background 255) (comment \"set camera in point [200, 200, 200]\") (comment \"the camera looks in direction of point [0, 0, 0]\") (comment \"\\\"up\\\" vector is [0, 0, -1]\") (q/camera 200 200 200 0 0 0 0 0 -1) (comment \"set camera to show only part of the scene according to following condition\") (comment \"between -100 and 100 left to right\") (comment \"between -100 and 100 top to bottm\") (comment \"between 300 and 350 points in front\") (q/frustum -100 100 -100 100 300 350) (comment \"draw box, it will appear cut as we frustum \") (comment \"limits to 300-350 region in fron of camera\") (q/stroke-weight 2) (q/stroke 0) (q/fill 127) (q/box 100) (comment \"draw red X axis\") (q/stroke 255 0 0) (q/line 0 0 0 100 0 0) (comment \"draw green Y axis\") (q/stroke 0 255 0) (q/line 0 0 0 0 100 0) (comment \"draw blue Z axis\") (q/stroke 0 0 255) (q/line 0 0 0 0 0 100))",
   :setup "()",
   :target :clj}
  {:fns ["camera"],
@@ -2267,15 +2192,7 @@
   :name "camera",
   :opts {:renderer :p3d, :settings nil},
   :draw
-  "((q/background 255) (q/camera 200 200 200 0 0 0 0 0 -1) (q/stroke-weight 2) (q/stroke 0) (q/fill 127) (q/box 100) (q/stroke 255 0 0) (q/line 0 0 0 100 0 0) (q/stroke 0 255 0) (q/line 0 0 0 0 100 0) (q/stroke 0 0 255) (q/line 0 0 0 0 0 100))",
-  :setup "()",
-  :target :clj}
- {:fns ["begin-camera" "end-camera" "camera"],
-  :ns "quil.snippets.lights-camera.camera",
-  :name "begin-camera-end-camera-camera",
-  :opts {:renderer :p3d, :settings nil},
-  :draw
-  "((q/background 255) (q/begin-camera) (q/camera) (q/translate 250 0 -250) (q/rotate-z (/ q/PI 4)) (q/rotate-x (/ q/PI 8)) (q/rotate-y (/ q/PI -8)) (q/end-camera) (q/stroke-weight 2) (q/stroke 0) (q/fill 127) (q/box 100) (q/stroke 255 0 0) (q/line 0 0 0 100 0 0) (q/stroke 0 255 0) (q/line 0 0 0 0 100 0) (q/stroke 0 0 255) (q/line 0 0 0 0 0 100))",
+  "((q/background 255) (comment \"set camera in point [200, 200, 200]\") (comment \"the camera looks in direction of point [0, 0, 0]\") (comment \"\\\"up\\\" vector is [0, 0, -1]\") (q/camera 200 200 200 0 0 0 0 0 -1) (comment \"draw a box of size 100 at the [0, 0, 0] point\") (q/stroke-weight 2) (q/stroke 0) (q/fill 127) (q/box 100) (comment \"draw red X axis\") (q/stroke 255 0 0) (q/line 0 0 0 100 0 0) (comment \"draw green Y axis\") (q/stroke 0 255 0) (q/line 0 0 0 0 100 0) (comment \"draw blue Z axis\") (q/stroke 0 0 255) (q/line 0 0 0 0 0 100))",
   :setup "()",
   :target :clj}
  {:fns ["unhex"],
@@ -2283,7 +2200,7 @@
   :name "unhex",
   :opts {:settings nil},
   :draw
-  "((q/background 255) (q/fill 0) (q/text (str (q/unhex \"2A\")) 10 10))",
+  "((q/background 255) (q/fill 0) (q/text (str \"(q/unhex \\\"2A\\\") = \" (q/unhex \"2A\")) 10 10))",
   :setup "()",
   :target :clj}
  {:fns ["unbinary"],
@@ -2291,7 +2208,7 @@
   :name "unbinary",
   :opts {:settings nil},
   :draw
-  "((q/background 255) (q/fill 0) (q/text (str (q/unbinary \"0101010\")) 10 10))",
+  "((q/background 255) (q/fill 0) (q/text (str \"(q/unbinary \\\"0101010\\\") = \" (q/unbinary \"0101010\")) 10 10))",
   :setup "()",
   :target :clj}
  {:fns ["hex"],
@@ -2299,7 +2216,7 @@
   :name "hex",
   :opts {:settings nil},
   :draw
-  "((q/background 255) (q/fill 0) (q/text (q/hex 42) 10 10) (q/text (q/hex 42 5) 10 30))",
+  "((q/background 255) (q/fill 0) (q/text (str \"(q/hex 42) = \" (q/hex 42)) 10 10) (q/text (str \"(q/hex 42 5) = \" (q/hex 42 5)) 10 30))",
   :setup "()",
   :target :clj}
  {:fns ["binary"],
@@ -2307,7 +2224,7 @@
   :name "binary",
   :opts {:settings nil},
   :draw
-  "((q/background 255) (q/fill 0) (q/text (q/binary 42) 10 10) (q/text (q/binary 42 5) 10 30))",
+  "((q/background 255) (q/fill 0) (q/text (str \"(q/binary 42) = \" (q/binary 42)) 10 10) (q/text (str \"(q/binary 42 5) = \" (q/binary 42 5)) 10 30))",
   :setup "()",
   :target :clj}
  {:fns ["with-stroke"],
@@ -2339,7 +2256,7 @@
   :name "stroke",
   :opts {:settings nil},
   :draw
-  "((q/background 255) (q/stroke-weight 10) (comment \"grey\") (q/stroke 120) (q/rect 0 0 100 100) (comment \"semitransparent light grey\") (q/stroke 80 120) (q/rect 70 70 100 100) (comment \"green\") (q/stroke 0 255 0) (q/rect 140 140 100 100) (comment \"semitransparent red\") (q/stroke 255 0 0 120) (q/rect 210 210 100 100))",
+  "((q/background 255) (q/stroke-weight 10) (comment \"grey\") (q/stroke 120) (q/rect 10 10 100 100) (comment \"semitransparent light grey\") (q/stroke 80 120) (q/rect 80 80 100 100) (comment \"green\") (q/stroke 0 255 0) (q/rect 150 150 100 100) (comment \"semitransparent red\") (q/stroke 255 0 0 120) (q/rect 220 220 100 100))",
   :setup "()",
   :target :clj}
  {:fns ["no-stroke"],
@@ -2347,7 +2264,7 @@
   :name "no-stroke",
   :opts {:settings nil},
   :draw
-  "((q/background 255) (comment \"set stroke to black\") (q/fill 120) (q/stroke 0) (q/rect 0 0 100 100) (comment \"remove stroke, no border around square\") (q/no-stroke) (q/rect 70 70 100 100))",
+  "((q/background 255) (q/stroke-weight 10) (comment \"set stroke to black\") (q/fill 120) (q/stroke 0) (q/rect 30 30 100 100) (comment \"remove stroke, no border around square\") (q/no-stroke) (q/rect 100 100 100 100))",
   :setup "()",
   :target :clj}
  {:fns ["no-fill"],
@@ -2373,7 +2290,7 @@
   :draw
   "((let [im (q/state :image)] (comment \"check if image is loaded by checking its size matches sketch size\") (when (= (.-width im) (q/width)) (q/background-image im))))",
   :setup
-  "(let [size (str (q/width) \"x\" (q/height)) _ (comment \"create url to image to used as background\") url (str \"https://dummyimage.com/\" size \"/2c3e50/ffffff.png\")] (q/set-state! :image (q/load-image url)))",
+  "(let [_ (comment \"create url to image to used as background\") url (str \"https://dummyimage.com/\" (q/width) \"x\" (q/height) \"/2c3e50/ffffff.png\")] (q/set-state! :image (q/load-image url)))",
   :target :clj}
  {:fns ["background"],
   :ns "quil.snippets.color.setting",
@@ -2396,7 +2313,7 @@
   :name "lerp-color",
   :opts {:settings nil},
   :draw
-  "((q/background 255) (let [c1 (q/color 255 0 0) c2 (q/color 0 0 255)] (comment \"draw colors that transition from c1 to c2\") (dotimes [i 6] (q/fill (q/lerp-color c1 c2 (/ i 5))) (q/rect (* i 70) (* i 70) 100 100))))",
+  "((q/background 255) (let [red (q/color 255 0 0) blue (q/color 0 0 255)] (comment \"draw colors that transition from red to blue\") (dotimes [i 6] (q/fill (q/lerp-color red blue (/ i 5))) (q/rect (* i 70) (* i 70) 100 100))))",
   :setup "()",
   :target :clj}
  {:fns ["current-stroke"],
@@ -2423,14 +2340,6 @@
   "((q/color-mode :rgb 255) (q/background 255) (comment \"use HSB and draw red\") (q/color-mode :hsb) (q/fill 255 255 255) (q/rect 0 0 100 100) (comment \"use HSB with different max and draw dark green\") (q/color-mode :hsb 5 10 20) (q/fill 2 10 5) (q/rect 70 70 100 100) (comment \"use RGB with 42 max value and draw 75% transparent blue\") (q/color-mode :rgb 40) (q/fill 0 0 40 30) (q/rect 140 140 100 100) (comment \"use RGB with different max values and draw semitransparent cyan\") (q/color-mode :rgb 5 10 20 30) (q/fill 0 10 20 15) (q/rect 210 210 100 100))",
   :setup "()",
   :target :clj}
- {:fns ["color-mode"],
-  :ns "quil.snippets.color.creating-and-reading",
-  :name "color-mode-hsb",
-  :opts {:settings nil},
-  :draw
-  "((q/color-mode :rgb 255) (q/background 255) (q/color-mode :hsb) (q/fill 255 255 255) (q/rect 0 0 100 100))",
-  :setup "()",
-  :target :clj}
  {:fns ["color"],
   :ns "quil.snippets.color.creating-and-reading",
   :name "color",
@@ -2444,7 +2353,7 @@
   :name "brightness",
   :opts {:settings nil},
   :draw
-  "((q/background 255) (q/color-mode :hsb) (let [col (q/color 100 230 100)] (q/fill col) (q/rect 0 0 100 100) (q/fill 255 255 (q/brightness col)) (q/rect 70 70 100 100)))",
+  "((q/background 255) (q/color-mode :hsb) (let [dark-green (q/color 100 230 100)] (q/fill dark-green) (q/rect 0 0 100 100) (comment \"use the same brightness but different color\") (q/fill 255 255 (q/brightness dark-green)) (q/rect 70 70 100 100)))",
   :setup "()",
   :target :clj}
  {:fns ["saturation"],
@@ -2452,7 +2361,7 @@
   :name "saturation",
   :opts {:settings nil},
   :draw
-  "((q/background 255) (q/color-mode :hsb) (let [col (q/color 100 230 100)] (q/fill col) (q/rect 0 0 100 100) (q/fill 255 (q/saturation col) 255) (q/rect 70 70 100 100)))",
+  "((q/background 255) (q/color-mode :hsb) (let [dark-green (q/color 100 230 100)] (q/fill dark-green) (q/rect 0 0 100 100) (comment \"use the same saturation but different color\") (q/fill 255 (q/saturation dark-green) 255) (q/rect 70 70 100 100)))",
   :setup "()",
   :target :clj}
  {:fns ["hue"],
@@ -2460,7 +2369,7 @@
   :name "hue",
   :opts {:settings nil},
   :draw
-  "((q/background 255) (q/color-mode :hsb) (let [col (q/color 100 230 100)] (q/fill col) (q/rect 0 0 100 100) (q/fill (q/hue col) 255 255) (q/rect 70 70 100 100)))",
+  "((q/background 255) (q/color-mode :hsb) (let [dark-green (q/color 100 230 100)] (q/fill dark-green) (q/rect 0 0 100 100) (comment \"use the hue (green) but make it bright\") (q/fill (q/hue dark-green) 255 255) (q/rect 70 70 100 100)))",
   :setup "()",
   :target :clj}
  {:fns ["blue"],
@@ -2468,7 +2377,7 @@
   :name "blue",
   :opts {:settings nil},
   :draw
-  "((q/background 255) (let [col (q/color 123 50 220)] (q/fill col) (q/rect 0 0 100 100) (q/fill 0 0 (q/blue col)) (q/rect 70 70 100 100)))",
+  "((q/background 255) (let [purple (q/color 123 50 220)] (q/fill purple) (q/rect 0 0 100 100) (comment \"use only blue component of purple\") (q/fill 0 0 (q/blue purple)) (q/rect 70 70 100 100)))",
   :setup "()",
   :target :clj}
  {:fns ["green"],
@@ -2476,7 +2385,7 @@
   :name "green",
   :opts {:settings nil},
   :draw
-  "((q/background 255) (let [col (q/color 123 50 220)] (q/fill col) (q/rect 0 0 100 100) (q/fill 0 (q/green col) 0) (q/rect 70 70 100 100)))",
+  "((q/background 255) (let [purple (q/color 123 50 220)] (q/fill purple) (q/rect 0 0 100 100) (comment \"use only green component of purple\") (q/fill 0 (q/green purple) 0) (q/rect 70 70 100 100)))",
   :setup "()",
   :target :clj}
  {:fns ["red"],
@@ -2484,7 +2393,7 @@
   :name "red",
   :opts {:settings nil},
   :draw
-  "((q/background 255) (let [col (q/color 123 50 220)] (q/fill col) (q/rect 0 0 100 100) (q/fill (q/red col) 0 0) (q/rect 70 70 100 100)))",
+  "((q/background 255) (let [purple (q/color 123 50 220)] (q/fill purple) (q/rect 0 0 100 100) (comment \"use only red component of purple\") (q/fill (q/red purple) 0 0) (q/rect 70 70 100 100)))",
   :setup "()",
   :target :clj}
  {:fns ["blend-color"],
@@ -2511,15 +2420,6 @@
   "((q/background 127) (let [gr (q/create-graphics 100 100)] (comment \"draw 4 circles of different color on the graphics\") (q/with-graphics gr (q/background 0 0) (q/fill 255) (q/ellipse 25 25 40 40) (q/fill 255 0 0) (q/ellipse 75 25 40 40) (q/fill 0 255 0) (q/ellipse 25 75 40 40) (q/fill 0 0 255) (q/ellipse 75 75 40 40)) (comment \"apply different types of tint\") (q/no-tint) (q/image gr 0 0) (q/tint 127) (q/image gr 120 0) (q/tint 255 127) (q/image gr 240 0) (q/tint 200 127 180) (q/image gr 0 120) (q/tint 200 127 180 127) (q/image gr 120 120)))",
   :setup "()",
   :target :clj}
- {:fns ["request-image"],
-  :ns "quil.snippets.image.loading-and-displaying",
-  :name "request-image",
-  :opts {:settings nil},
-  :draw
-  "((if (zero? (.-width (q/state :image))) (q/text \"Loading\" 10 10) (q/image (q/state :image) 0 0)))",
-  :setup
-  "(q/set-state! :image (q/request-image \"https://dummyimage.com/100x100/2c3e50/ffffff.png\"))",
-  :target :clj}
  {:fns ["no-tint"],
   :ns "quil.snippets.image.loading-and-displaying",
   :name "no-tint",
@@ -2531,9 +2431,9 @@
  {:fns ["mask-image"],
   :ns "quil.snippets.image.loading-and-displaying",
   :name "mask-image",
-  :opts {:renderer :p3d, :settings nil},
+  :opts {:settings nil},
   :draw
-  "((q/background 255) (comment \"define 2 graphics and mask to apply to them\") (let [gr (q/create-graphics 100 100 :p3d) gr2 (q/create-graphics 100 100 :p3d) mask (q/create-graphics 100 100 :p3d)] (comment \"first graphic is blue square with red crossing\") (q/with-graphics gr (q/background 0 0 255) (q/stroke-weight 3) (q/stroke 255 0 0) (q/line 0 0 100 100) (q/line 0 100 100 0)) (comment \"second graphic is green cross\") (q/with-graphics gr2 (q/background 255) (q/stroke 0 255 0) (q/stroke-weight 5) (q/line 0 50 100 50) (q/line 50 0 50 100)) (comment \"mask is grey circles\") (q/with-graphics mask (q/background 0) (q/stroke-weight 5) (q/no-fill) (q/stroke 255) (q/ellipse 50 50 10 10) (q/stroke 200) (q/ellipse 50 50 30 30) (q/stroke 150) (q/ellipse 50 50 50 50) (q/stroke 100) (q/ellipse 50 50 70 70) (q/stroke 50) (q/ellipse 50 50 90 90)) (comment \"draw first graphic, mask and graphic with mask applied\") (q/image gr 20 20) (q/image mask 140 20) (q/mask-image gr mask) (q/image gr 260 20) (comment \"draw second graphic, mask and graphic with mask applied\") (q/image gr2 20 140) (q/image mask 140 140) (q/with-graphics gr2 (q/mask-image mask)) (q/image gr2 260 140)))",
+  "((q/background 255) (comment \"define 2 images and a mask to apply to them\") (let [im (q/create-image 100 100 :argb) im2 (q/create-image 100 100 :argb) mask (q/create-image 100 100 :argb)] (comment \"first image is a blue square with a red cross\") (dotimes [x 100] (dotimes [y 100] (if (or (< 0 (- x y) 5) (< 95 (+ x y) 100)) (q/set-pixel im x y (q/color 255 0 0 255)) (q/set-pixel im x y (q/color 0 0 255))))) (comment \"second image is a green cross\") (dotimes [x 100] (dotimes [y 5] (q/set-pixel im2 (+ y 47) x (q/color 0 255 0)) (q/set-pixel im2 x (+ y 47) (q/color 0 255 0)))) (comment \"mask is rectangles with different shades of gray\") (dotimes [x 100] (dotimes [y 100] (q/set-pixel mask x y (q/color 0 (* 40 (+ (quot x 20) (quot y 20))))))) (comment \"draw first image, mask and image with mask applied\") (q/image im 20 20) (q/image mask 140 20) (q/mask-image im mask) (q/image im 260 20) (comment \"draw second image, mask and image with mask applied\") (q/image im2 20 140) (q/image mask 140 140) (q/mask-image im2 mask) (q/image im2 260 140)))",
   :setup "()",
   :target :clj}
  {:fns ["load-image"],
@@ -2541,9 +2441,9 @@
   :name "load-image",
   :opts {:settings nil},
   :draw
-  "((let [im (q/state :image)] (comment \"image is loaded once its width is non-zero\") (when-not (zero? (.-width im)) (q/image im 0 0))))",
+  "((let [im (q/state :image)] (comment \"check if image is loaded using function loaded?\") (when (q/loaded? im) (q/image im 0 0))))",
   :setup
-  "(let [_ (comment \"create url to load image 100x100\") url (str \"https://dummyimage.com/100x100/2c3e50/ffffff.png\")] (q/set-state! :image (q/load-image url)))",
+  "(let [_ (comment \"create url to load image 100x100\") url \"https://dummyimage.com/100x100/2c3e50/ffffff.png\"] (q/set-state! :image (q/load-image url)))",
   :target :clj}
  {:fns ["image-mode"],
   :ns "quil.snippets.image.loading-and-displaying",
@@ -2561,7 +2461,7 @@
   "((q/background 255) (comment \"create graphics with circle\") (let [gr (q/create-graphics 70 70)] (q/with-graphics gr (q/ellipse 35 35 70 70)) (comment \"draw graphics twice\") (q/image gr 0 0) (q/image gr 100 0 100 70)))",
   :setup "()",
   :target :clj}
- {:fns ["set-image"],
+ {:fns ["set-image" "set-pixel"],
   :ns "quil.snippets.image.pixels",
   :name "set-image",
   :opts {:settings nil},
@@ -2598,7 +2498,7 @@
   :name "display-filter",
   :opts {:settings nil},
   :draw
-  "((q/background 255) (let [orig (q/create-graphics 100 100) modes [[:threshold] [:threshold 0.7] [:gray] [:invert] [:posterize 20] [:blur] [:blur 3] [:opaque] [:erode] [:dilate]] splitted (partition-all 4 modes)] (comment \"draw 10x10 square from circles of different color\") (q/with-graphics orig (q/color-mode :rgb 1.0) (q/background 1) (q/no-stroke) (q/ellipse-mode :corner) (doseq [r (range 0 1 0.1) b (range 0 1 0.1)] (q/fill r 0 b) (q/ellipse (* r 100) (* b 100) 10 10))) (comment \"apply different filters, four filters per row\") (q/image orig 0 0) (dotimes [row (count splitted)] (dotimes [col (count (nth splitted row))] (let [mode (nth (nth splitted row) col) dest (q/create-graphics 100 100)] (q/with-graphics dest (q/image orig 0 0) (apply q/display-filter mode)) (q/image dest (* col 120) (* 120 (inc row))))))))",
+  "((q/background 255) (let [orig (q/create-graphics 100 100) modes [[:threshold] [:threshold 0.2] [:gray] [:invert] [:posterize 20] [:blur] [:blur 3] [:opaque] [:erode] [:dilate]] splitted (partition-all 4 modes)] (comment \"draw 10x10 square from circles of different color\") (q/with-graphics orig (q/color-mode :rgb 1.0) (q/background 1) (q/no-stroke) (q/ellipse-mode :corner) (doseq [r (range 0 1 0.1) b (range 0 1 0.1)] (q/fill r 0 b) (q/ellipse (* r 100) (* b 100) 10 10))) (comment \"apply different filters, four filters per row\") (q/image orig 0 0) (dotimes [row (count splitted)] (dotimes [col (count (nth splitted row))] (let [mode (nth (nth splitted row) col) dest (q/create-graphics 100 100)] (q/with-graphics dest (q/image orig 0 0) (apply q/display-filter mode)) (q/image dest (* col 120) (* 120 (inc row))))))))",
   :setup "()",
   :target :clj}
  {:fns ["image-filter"],
@@ -2606,7 +2506,7 @@
   :name "image-filter",
   :opts {:settings nil},
   :draw
-  "((q/background 255) (let [orig (q/create-graphics 100 100) modes [[:threshold] [:threshold 0.7] [:gray] [:invert] [:posterize 20] [:blur] [:blur 3] [:opaque] [:erode] [:dilate]] splitted (partition-all 4 modes)] (comment \"draw 10x10 square from circles of different color\") (q/with-graphics orig (q/color-mode :rgb 1.0) (q/background 1) (q/no-stroke) (q/ellipse-mode :corner) (doseq [r (range 0 1 0.1) b (range 0 1 0.1)] (q/fill r 0 b) (q/ellipse (* r 100) (* b 100) 10 10))) (comment \"apply different filters, four filters per row\") (q/image orig 0 0) (dotimes [row (count splitted)] (dotimes [col (count (nth splitted row))] (let [mode (nth (nth splitted row) col) clone (q/get-pixel orig)] (apply q/image-filter clone mode) (q/image clone (* col 120) (* 120 (inc row))))))))",
+  "((q/background 255) (let [orig (q/create-graphics 100 100) modes [[:threshold] [:threshold 0.2] [:gray] [:invert] [:posterize 20] [:blur] [:blur 3] [:opaque] [:erode] [:dilate]] splitted (partition-all 4 modes)] (comment \"draw 10x10 square from circles of different color\") (q/with-graphics orig (q/color-mode :rgb 1.0) (q/background 1) (q/no-stroke) (q/ellipse-mode :corner) (doseq [r (range 0 1 0.1) b (range 0 1 0.1)] (q/fill r 0 b) (q/ellipse (* r 100) (* b 100) 10 10))) (comment \"apply different filters, four filters per row\") (q/image orig 0 0) (dotimes [row (count splitted)] (dotimes [col (count (nth splitted row))] (let [mode (nth (nth splitted row) col) clone (q/get-pixel orig)] (apply q/image-filter clone mode) (q/image clone (* col 120) (* 120 (inc row))))))))",
   :setup "()",
   :target :clj}
  {:fns ["copy"],
@@ -2622,8 +2522,8 @@
   :name "blend",
   :opts {:settings nil},
   :draw
-  "((q/background 255 100 20 50) (let [gr (q/create-graphics 50 50) modes [:blend :add :subtract :darkest :lightest :difference :exclusion :multiply :screen :overlay :hard-light :soft-light :dodge :burn] splitted (partition-all 5 modes)] (comment \"draw 3 circles of different color on the graphics\") (q/with-graphics gr (q/background 40 200 255 200) (q/fill 255 0 0) (q/ellipse 12 12 20 20) (q/fill 0 255 0) (q/ellipse 38 12 20 20) (q/fill 0 0 255) (q/ellipse 25 38 20 20)) (comment \"all possible blended modes\") (dotimes [row (count splitted)] (dotimes [col (count (nth splitted row))] (let [mode (nth (nth splitted row) col)] (comment \"blend with sketch itself\") (q/blend 400 0 50 50 (* col 55) (* row 55) 50 50 mode) (comment \"blend with graphics\") (q/blend gr 0 0 50 50 (* col 55) (+ 170 (* row 55)) 50 50 mode) (comment \"blend graphics to graphics\") (q/blend gr (q/current-graphics) 0 0 50 50 (* col 55) (+ 340 (* row 55)) 50 50 mode))))))",
-  :setup "()",
+  "((q/background 255 100 20 50) (let [im (q/create-image 50 50 :rgb) modes [:blend :add :subtract :darkest :lightest :difference :exclusion :multiply :screen :overlay :hard-light :soft-light :dodge :burn] splitted (partition-all 5 modes)] (comment \"draw 3 squares of different color on the graphics\") (dotimes [x 10] (dotimes [y 10] (q/set-pixel im (+ x 10) (+ y 10) (q/color 255 0 0)) (q/set-pixel im (+ x 30) (+ y 10) (q/color 0 255 0)) (q/set-pixel im (+ x 20) (+ y 30) (q/color 0 0 255)))) (comment \"draw all possible blended modes\") (dotimes [row (count splitted)] (dotimes [col (count (nth splitted row))] (let [mode (nth (nth splitted row) col)] (comment \"blend with sketch itself\") (q/blend 400 0 50 50 (* col 55) (* row 55) 50 50 mode) (comment \"blend with image\") (q/blend im 0 0 50 50 (* col 55) (+ 170 (* row 55)) 50 50 mode) (comment \"blend image to image\") (q/blend im (q/current-graphics) 0 0 50 50 (* col 55) (+ 340 (* row 55)) 50 50 mode))))))",
+  :setup "(q/no-loop)",
   :target :clj}
  {:fns ["create-graphics"],
   :ns "quil.snippets.image.rendering",
@@ -2638,7 +2538,7 @@
   :name "blend-mode",
   :opts {:renderer :p2d, :settings nil},
   :draw
-  "((q/background 255) (let [modes [:replace :blend :add :subtract :darkest :lightest :exclusion :multiply :screen] splitted (partition-all 4 modes)] (dotimes [row (count splitted)] (dotimes [col (count (nth splitted row))] (let [mode (nth (nth splitted row) col) gr (q/create-graphics 100 100 :p2d)] (q/with-graphics gr (q/background 127) (q/blend-mode mode) (q/no-stroke) (q/fill 255 0 0) (q/rect 10 20 80 20) (q/fill 50 170 255 127) (q/rect 60 10 20 80) (q/fill 200 130 150 200) (q/rect 10 60 80 20) (q/fill 20 240 50 50) (q/rect 20 10 20 80)) (q/image gr (* col 120) (* row 120)))))))",
+  "((q/background 255) (let [modes [:replace :blend :add :subtract :darkest :lightest :difference :exclusion :multiply :screen] splitted (partition-all 4 modes)] (dotimes [row (count splitted)] (dotimes [col (count (nth splitted row))] (let [mode (nth (nth splitted row) col) gr (q/create-graphics 100 100 :p2d)] (q/with-graphics gr (q/background 127) (q/blend-mode mode) (q/no-stroke) (q/fill 255 0 0) (q/rect 10 20 80 20) (q/fill 50 170 255 127) (q/rect 60 10 20 80) (q/fill 200 130 150 200) (q/rect 10 60 80 20) (q/fill 20 240 50 50) (q/rect 20 10 20 80)) (q/image gr (* col 120) (* row 120)))))))",
   :setup "()",
   :target :clj}
  {:fns ["translate"],
@@ -2646,7 +2546,7 @@
   :name "translate",
   :opts {:renderer :p3d, :settings nil},
   :draw
-  "((q/camera 200 200 200 0 0 0 0 0 -1) (q/no-fill) (q/box 50) (q/translate 100 0) (q/box 50) (q/translate [-100 100]) (q/box 50) (q/translate 0 -100 100) (q/box 50))",
+  "((comment \"setup camera and draw box at [0 0 0]\") (q/camera 200 200 200 0 0 0 0 0 -1) (q/no-fill) (q/box 50) (comment \"draw 3 identical boxes in 3 different positions\") (comment \"using different translate calls\") (q/translate 100 0) (q/box 50) (q/translate [-100 100]) (q/box 50) (q/translate 0 -100 100) (q/box 50))",
   :setup "()",
   :target :clj}
  {:fns ["shear-x" "shear-y"],
@@ -2654,7 +2554,7 @@
   :name "shear-x-y",
   :opts {:settings nil},
   :draw
-  "((q/with-translation [125 125] (q/rect 0 0 100 50)) (q/with-translation [375 125] (q/shear-y 0.5) (q/rect 0 0 100 50)) (q/with-translation [125 375] (q/shear-x 0.5) (q/rect 0 0 100 50)))",
+  "((comment \"draw normal rect\") (q/with-translation [125 125] (q/rect 0 0 100 50)) (comment \"draw rect sheared by y\") (q/with-translation [375 125] (q/shear-y 0.5) (q/rect 0 0 100 50)) (comment \"draw rect sheared by x\") (q/with-translation [125 375] (q/shear-x 0.5) (q/rect 0 0 100 50)))",
   :setup "()",
   :target :clj}
  {:fns ["scale"],
@@ -2662,7 +2562,7 @@
   :name "scale",
   :opts {:renderer :p3d, :settings nil},
   :draw
-  "((q/camera 200 200 200 0 0 0 0 0 -1) (q/no-fill) (q/box 50) (q/with-translation [100 0 0] (q/scale 0.5) (q/box 50) (q/scale 2)) (q/with-translation [0 100 0] (q/scale 1 0.5) (q/box 50) (q/scale 1 2)) (q/with-translation [0 0 100] (q/scale 0.5 1 1.5) (q/box 50) (q/scale 2 1 0.75)))",
+  "((comment \"setup camera and draw box at [0 0 0]\") (q/camera 200 200 200 0 0 0 0 0 -1) (q/no-fill) (q/box 50) (comment \"draw box 50% smaller\") (q/with-translation [100 0 0] (q/scale 0.5) (q/box 50) (q/scale 2)) (comment \"draw box 50% narrower but same length/height\") (q/with-translation [0 100 0] (q/scale 1 0.5) (q/box 50) (q/scale 1 2)) (comment \"draw box 50% shorter and 150% taller, but same width\") (q/with-translation [0 0 100] (q/scale 0.5 1 1.5) (q/box 50) (q/scale 2 1 0.75)))",
   :setup "()",
   :target :clj}
  {:fns ["rotate-x" "rotate-y" "rotate-z"],
@@ -2670,7 +2570,7 @@
   :name "rotate-x-y-z",
   :opts {:renderer :p3d, :settings nil},
   :draw
-  "((q/camera 200 200 200 0 0 0 0 0 -1) (q/no-fill) (q/box 50) (q/push-matrix) (q/translate 100 0 0) (q/rotate-x 0.5) (q/box 50) (q/pop-matrix) (q/push-matrix) (q/translate 0 100 0) (q/rotate-y 0.5) (q/box 50) (q/pop-matrix) (q/push-matrix) (q/translate 0 0 100) (q/rotate-z 0.5) (q/box 50) (q/pop-matrix))",
+  "((comment \"setup camera and draw box at [0 0 0]\") (q/camera 200 200 200 0 0 0 0 0 -1) (q/no-fill) (q/box 50) (q/push-matrix) (comment \"move, rotate x axis and draw box\") (q/translate 100 0 0) (q/rotate-x 0.5) (q/box 50) (q/pop-matrix) (q/push-matrix) (comment \"move, rotate y axis and draw box\") (q/translate 0 100 0) (q/rotate-y 0.5) (q/box 50) (q/pop-matrix) (q/push-matrix) (comment \"move, rotate z axis and draw box\") (q/translate 0 0 100) (q/rotate-z 0.5) (q/box 50) (q/pop-matrix))",
   :setup "()",
   :target :clj}
  {:fns ["rotate"],
@@ -2686,7 +2586,7 @@
   :name "reset-matrix",
   :opts {:settings nil},
   :draw
-  "((q/rect 0 0 100 50) (q/translate 250 250) (q/rect 0 0 50 50) (q/reset-matrix) (q/rect 0 0 50 100))",
+  "((q/rect 0 0 100 50) (q/translate 250 250) (q/rect 0 0 50 50) (comment \"resetting brings us back to [0, 0]\") (q/reset-matrix) (q/rect 0 0 50 100))",
   :setup "()",
   :target :clj}
  {:fns ["print-matrix"],
@@ -2702,7 +2602,7 @@
   :name "push-matrix-pop-matrix",
   :opts {:settings nil},
   :draw
-  "((q/fill 255 0 0) (q/translate 20 20) (q/rect 0 0 50 50) (q/translate 150 0) (q/push-matrix) (q/rotate 1) (q/rect 0 0 50 50) (q/pop-matrix) (q/translate 150 0) (q/rect 0 0 50 50))",
+  "((q/fill 255 0 0) (comment \"draw rect at [20, 20]\") (q/translate 20 20) (q/rect 0 0 50 50) (comment \"move by 150 to right and save matrix\") (q/translate 150 0) (q/push-matrix) (comment \"rotate matrix and draw rect\") (q/rotate 1) (q/rect 0 0 50 50) (comment \"pop matrix should revert rotation\") (q/pop-matrix) (comment \"move by another 150 pixels and draw rect\") (q/translate 150 0) (q/rect 0 0 50 50))",
   :setup "()",
   :target :clj}
  {:fns ["apply-matrix"],
@@ -2710,7 +2610,7 @@
   :name "apply-matrix",
   :opts {:renderer :p3d, :settings nil},
   :draw
-  "((q/camera 200 200 200 0 0 0 0 0 -1) (q/no-fill) (q/box 50) (q/apply-matrix 1 0 50 0 1 -50) (q/box 50) (let [s (q/sin 1) c (q/cos 1)] (q/apply-matrix 1 0 0 0 0 c s 50 0 (- s) c -50 0 0 0 1)) (q/box 50))",
+  "((comment \"setup camera\") (q/camera 200 200 200 0 0 0 0 0 -1) (q/no-fill) (comment \"draw box at [0 0 0]\") (q/box 50) (comment \"move positiion by [50 -50 0] and draw box\") (q/apply-matrix 1 0 50 0 1 -50) (q/box 50) (comment \"rotate position and move by [0 50 -50] and draw box\") (let [s (q/sin 1) c (q/cos 1)] (q/apply-matrix 1 0 0 0 0 c s 50 0 (- s) c -50 0 0 0 1)) (q/box 50))",
   :setup "()",
   :target :clj}
  {:fns ["looping?"],
@@ -2750,7 +2650,7 @@
   :name "clip-no-clip",
   :opts {:settings nil},
   :draw
-  "((q/no-clip) (q/background 255) (q/fill 0) (q/clip 50 100 100 100) (q/triangle 100 70 170 180 30 180) (q/no-clip) (q/with-translation [(/ (q/width) 2) (/ (q/height) 2)] (q/triangle 100 70 170 180 30 180)))",
+  "((q/background 255) (q/fill 0) (comment \"clip rendering so that triangle will be incomplete\") (q/clip 50 100 100 100) (q/triangle 100 70 170 180 30 180) (comment \"draw normal unclipped triangle\") (q/no-clip) (q/with-translation [(/ (q/width) 2) (/ (q/height) 2)] (q/triangle 100 70 170 180 30 180)))",
   :setup "()",
   :target :clj}
  {:fns ["load-shader"],
@@ -2840,6 +2740,14 @@
   "((q/background 255) (q/fill 0) (doseq [[ind capt fn] [[0 \"key-as-keyword\" q/key-as-keyword] [1 \"key-code\" q/key-code] [2 \"key-coded?\" (fn* [] (q/key-coded? (q/raw-key)))] [3 \"key-pressed?\" q/key-pressed?] [4 \"raw-key\" q/raw-key] [5 \"key-modifiers\" q/key-modifiers]]] (q/text (str capt \" \" (fn)) 10 (+ (* 20 ind) 20))))",
   :setup "()",
   :target :clj}
+ {:fns ["resize-sketch"],
+  :ns "quil.snippets.environment",
+  :name "resize-sketch",
+  :opts {:settings nil},
+  :draw
+  "((q/frame-rate 1) (comment \"each frame increase size of sketch\") (q/resize-sketch (inc (q/width)) (inc (q/height))) (q/background 255) (q/fill 0) (q/text (str \"width: \" (q/width) \", height: \" (q/height)) 10 20))",
+  :setup "()",
+  :target :clj}
  {:fns ["pixel-density"],
   :ns "quil.snippets.environment",
   :name "pixel-density",
@@ -2853,7 +2761,7 @@
   :name "display-density",
   :opts {:settings nil},
   :draw
-  "((q/background 255) (q/fill 0) (q/text-num (q/display-density) 10 20))",
+  "((q/background 255) (q/fill 0) (q/text (str \"display density: \" (q/display-density)) 10 20))",
   :setup "()",
   :target :clj}
  {:fns ["screen-width" "screen-height"],
@@ -2864,19 +2772,12 @@
   "((q/background 255) (q/fill 0) (let [w (q/screen-width) h (q/screen-height)] (q/text (str w \"x\" h) 10 20)))",
   :setup "()",
   :target :clj}
- {:fns ["no-cursor"],
-  :ns "quil.snippets.environment",
-  :name "no-cursor",
-  :opts {:settings nil},
-  :draw "((q/no-cursor))",
-  :setup "()",
-  :target :clj}
  {:fns ["height" "width"],
   :ns "quil.snippets.environment",
   :name "height-width",
   :opts {:settings nil},
   :draw
-  "((q/background 255) (q/fill 0) (q/text (str (q/width) \"x\" (q/height)) 10 20))",
+  "((q/background 255) (q/fill 0) (q/text (str \"width: \" (q/width) \", height: \" (q/height)) 10 20))",
   :setup "()",
   :target :clj}
  {:fns ["frame-rate"],
@@ -2884,7 +2785,7 @@
   :name "frame-rate",
   :opts {:settings nil},
   :draw
-  "((q/background 255) (q/fill 0) (q/text (str (q/target-frame-rate)) 10 20) (q/frame-rate (inc (rand-int 5))))",
+  "((q/background 255) (q/fill 0) (q/text (str \"Frame rate: \" (q/target-frame-rate)) 10 20) (let [frame (q/frame-count)] (comment \"draw moving box\") (q/rect (rem frame (q/width)) 50 50 50) (comment \"every 10 frames change frame rate\") (comment \"frame rate cycles through [1, 6, 11, 16, 21]\") (when (zero? (rem frame 10)) (q/frame-rate (inc (* 5 (rem (quot frame 10) 5)))))))",
   :setup "()",
   :target :clj}
  {:fns ["frame-count"],
@@ -2892,7 +2793,7 @@
   :name "frame-count",
   :opts {:settings nil},
   :draw
-  "((q/background 255) (q/fill 0) (q/text (str (q/frame-count)) 10 20))",
+  "((q/background 255) (q/fill 0) (q/text (str \"Frame count: \" (q/frame-count)) 10 20))",
   :setup "()",
   :target :clj}
  {:fns ["focused"],
@@ -2900,7 +2801,7 @@
   :name "focused",
   :opts {:settings nil},
   :draw
-  "((q/background 255) (q/fill 0) (q/text (str (q/focused)) 10 20))",
+  "((q/background 255) (q/fill 0) (q/text (str \"Focused: \" (q/focused)) 10 20))",
   :setup "()",
   :target :clj}
  {:fns ["cursor-image"],
@@ -2910,14 +2811,14 @@
   :draw
   "((if (zero? (.-width (q/state :image))) (q/text \"Loading\" 10 10) (do (q/cursor-image (q/state :image)) (q/cursor-image (q/state :image) 16 16) (q/image (q/state :image) 0 0))))",
   :setup
-  "(q/set-state! :image (q/request-image \"test/html/cursor.jpg\"))",
+  "(q/set-state! :image (q/load-image \"test/html/cursor.jpg\"))",
   :target :clj}
- {:fns ["cursor"],
+ {:fns ["cursor" "no-cursor"],
   :ns "quil.snippets.environment",
-  :name "cursor",
+  :name "cursor-no-cursor",
   :opts {:settings nil},
   :draw
-  "((q/no-cursor) (q/cursor) (doseq [type [:arrow :cross :hand :move :text :wait]] (q/cursor type)))",
+  "((q/background 255) (q/rect-mode :corners) (q/text-align :center :center) (comment \"iterate through all types of cursors\") (let [types [:arrow :cross :hand :move :text :wait :no-cursor :default] box-width (/ (q/width) 4.1) box-height (/ (q/height) 2.1)] (dotimes [ind (count types)] (let [type (nth types ind) _ (comment \"calculate corners of current box\") x (* box-width (rem ind 4)) y (* box-height (quot ind 4)) n-x (+ x box-width) n-y (+ y box-height)] (comment \"draw a box for current type with its name in center\") (q/stroke 127) (q/no-fill) (q/rect x y n-x n-y) (q/no-stroke) (q/fill 0) (q/text (str type) (/ (+ x n-x) 2) (/ (+ y n-y) 2)) (comment \"if mouse is inside the box - enable this type\") (when (and (<= x (q/mouse-x) n-x) (<= y (q/mouse-y) n-y)) (condp = type :default (q/cursor) :no-cursor (q/no-cursor) (q/cursor type)))))))",
   :setup "()",
   :target :clj}
  {:fns ["current-graphics"],
@@ -2933,7 +2834,7 @@
   :name "current-frame-rate-target-frame-rate",
   :opts {:settings nil},
   :draw
-  "((q/background 255) (q/fill 0) (q/text (str (q/current-frame-rate)) 10 20) (q/text (str (q/target-frame-rate)) 10 40))",
+  "((q/background 255) (q/fill 0) (q/text (str \"(q/current-frame-rate) = \" (q/current-frame-rate)) 10 20) (q/text (str \"(q/target-frame-rate) = \" (q/target-frame-rate)) 10 40))",
   :setup "()",
   :target :clj}
  {:fns ["resize"],

--- a/src/clj/quil_site/controllers/api.clj
+++ b/src/clj/quil_site/controllers/api.clj
@@ -19,7 +19,7 @@
                    (into (sorted-map)))
              categories)))
 
-(def all-fns (edn/read-string (slurp "api-2.8.0.clj")))
+(def all-fns (edn/read-string (slurp "api-3.0.0.clj")))
 
 (def fns-by-categories (split-into-categories all-fns))
 

--- a/src/clj/quil_site/snippets.clj
+++ b/src/clj/quil_site/snippets.clj
@@ -12,7 +12,7 @@
          (assoc snippet :fn fn))
        (group-by :fn)))
 
-(def ^:private snippets (edn/read-string (slurp "snippets-data-2.8.0.clj")))
+(def ^:private snippets (edn/read-string (slurp "snippets-data-3.0.0.clj")))
 
 (def ^:private zprint-options
   {:parse-string-all? true

--- a/src/cljs/main/quil_site/main.cljs
+++ b/src/cljs/main/quil_site/main.cljs
@@ -39,20 +39,10 @@
   (->> (cstr/replace name " " "-")
        (str "/sketches/show/example_")))
 
-(defn pause-after-next-frame [sketch]
-  (let [real-sketch (aget (aget sketch "externals") "sketch")
-        set-on-frame-end #(aset real-sketch "onFrameEnd" %)]
-    (set-on-frame-end
-     (fn []
-       (q/with-sketch sketch
-         (q/no-loop))
-       (set-on-frame-end (fn []))))))
-
 (defn should-start-paused? []
   (boolean (query-selector ".container.examples-page")))
 
 (defn setup-play-pause-functionality [host sketch]
-  ;; (pause-after-next-frame sketch)
   (let [play-button (query-selector host ".play")
         pause-button (query-selector host ".pause")]
     (classes/remove play-button "hidden")
@@ -66,7 +56,8 @@
                      (classes/remove pause-button "invisible")))
     (events/listen pause-button EventType/CLICK
                    (fn []
-                     (pause-after-next-frame sketch)
+                     (q/with-sketch sketch
+                       (q/no-loop))
                      (classes/remove play-button "hidden")
                      (classes/add pause-button "invisible")))))
 
@@ -89,9 +80,11 @@
                         (str "by " author))
     (let [sketch (run-fn (query-selector host ".canvas-container") 200)]
       (when (should-start-paused?)
+        (q/with-sketch sketch
+          (q/no-loop))
         (setup-play-pause-functionality host sketch))
-        (when white-play-button?
-          (classes/add (query-selector host ".play") "white")))))
+      (when white-play-button?
+        (classes/add (query-selector host ".play") "white")))))
 
 (defn register-example! [name author run-fn &
                          {:keys [interactive? display-name]


### PR DESCRIPTION
Follow up to [my last pull request](https://github.com/quil/quil-site/pull/25):
1. Updated snippets data and api as recommended
2. Regarding pausing after rendering the first frame I tried approach 2 you suggested but that didn't work. If I understood correctly this is because the `q/no-loop` marked with `;DELETE` is only removed when shown to the user but not for rendering on the examples page. But I managed to achieve the intended functionality with `q/no-loop` in `run-example`. What do you think?